### PR TITLE
Remove default version to PRODUCTION

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -1,6 +1,6 @@
 module.exports = {
   extends: [
-    '@yext/slapshot/typescript'
+    '@yext/eslint-config'
   ],
-  ignorePatterns: ['dist'],
+  ignorePatterns: ['dist', 'test*'],
 };

--- a/package-lock.json
+++ b/package-lock.json
@@ -14,7 +14,7 @@
         "@babel/preset-env": "^7.21.5",
         "@babel/preset-typescript": "^7.21.5",
         "@types/jest": "^29.5.1",
-        "@yext/eslint-config-slapshot": "^0.7.0",
+        "@yext/eslint-config": "^1.0.0",
         "babel-jest": "^29.5.0",
         "eslint": "^8.39.0",
         "jest": "^29.5.0",
@@ -3121,20 +3121,21 @@
         "url": "https://opencollective.com/typescript-eslint"
       }
     },
-    "node_modules/@yext/eslint-config-slapshot": {
-      "version": "0.7.0",
-      "resolved": "https://registry.npmjs.org/@yext/eslint-config-slapshot/-/eslint-config-slapshot-0.7.0.tgz",
-      "integrity": "sha512-VTZ3FJ9siCzxzaZU4fgx/zZizlnGIDxWmFYAgdnlGMmPUIyvOtzzi6B9WwNR3trtFrkE49QGBv2LnVsAMCzY8g==",
+    "node_modules/@yext/eslint-config": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/@yext/eslint-config/-/eslint-config-1.0.0.tgz",
+      "integrity": "sha512-U0bCc63lIPab1jEXleyiEXpMWvPERWZuHXnZRHa0qJcBMPdgDzXJDaamx1vYGRfDebZh1w+ut8TE8/mj9/YcOQ==",
       "dev": true,
       "hasInstallScript": true,
       "dependencies": {
+        "eslint-config-prettier": "^8.5.0",
         "eslint-config-react-app": "^7.0.1"
       },
       "peerDependencies": {
-        "@typescript-eslint/eslint-plugin": "^5.37.0",
-        "@yext/eslint-plugin-export-star": "^1.2.0",
+        "@typescript-eslint/eslint-plugin": "^5.35.1",
+        "@typescript-eslint/parser": "^5.35.1",
+        "@yext/eslint-plugin-export-star": "^1.0.2",
         "eslint": ">= 7",
-        "eslint-plugin-react-hooks": "^4.6.0",
         "eslint-plugin-react-perf": "^3.3.1",
         "eslint-plugin-tsdoc": "^0.2.14"
       }
@@ -4478,6 +4479,18 @@
       },
       "funding": {
         "url": "https://opencollective.com/eslint"
+      }
+    },
+    "node_modules/eslint-config-prettier": {
+      "version": "8.8.0",
+      "resolved": "https://registry.npmjs.org/eslint-config-prettier/-/eslint-config-prettier-8.8.0.tgz",
+      "integrity": "sha512-wLbQiFre3tdGgpDv67NQKnJuTlcUVYHas3k+DZCc2U2BadthoEY4B7hLPvAxaqdyOGCzuLfii2fqGph10va7oA==",
+      "dev": true,
+      "bin": {
+        "eslint-config-prettier": "bin/cli.js"
+      },
+      "peerDependencies": {
+        "eslint": ">=7.0.0"
       }
     },
     "node_modules/eslint-config-react-app": {

--- a/package.json
+++ b/package.json
@@ -45,7 +45,7 @@
     "@babel/preset-env": "^7.21.5",
     "@babel/preset-typescript": "^7.21.5",
     "@types/jest": "^29.5.1",
-    "@yext/eslint-config-slapshot": "^0.7.0",
+    "@yext/eslint-config": "^1.0.0",
     "babel-jest": "^29.5.0",
     "eslint": "^8.39.0",
     "jest": "^29.5.0",

--- a/src/ChatCore.ts
+++ b/src/ChatCore.ts
@@ -40,7 +40,7 @@ export class ChatCore {
   async getNextMessage(request: MessageRequest): Promise<MessageResponse> {
     const queryParams: QueryParams = { v: defaultApiVersion };
     const body: ApiMessageRequest = {
-      version: this.chatConfig.version || 'PRODUCTION',
+      version: this.chatConfig.version,
       messages: request.messages,
       notes: request.notes
     };

--- a/src/models/endpoints/MessageRequest.ts
+++ b/src/models/endpoints/MessageRequest.ts
@@ -26,7 +26,7 @@ export interface MessageRequest {
  */
 export interface ApiMessageRequest {
   /** {@inheritDoc ChatConfig.version} */
-  version: 'STAGING' | 'PRODUCTION' | number,
+  version?: 'STAGING' | 'PRODUCTION' | number,
   /** {@inheritDoc MessageRequest.messages} */
   messages: Message[],
   /** {@inheritDoc MessageNotes} */

--- a/test-browser-esm/package-lock.json
+++ b/test-browser-esm/package-lock.json
@@ -28,8 +28,10 @@
       "devDependencies": {
         "@babel/preset-env": "^7.21.5",
         "@babel/preset-typescript": "^7.21.5",
+        "@microsoft/api-documenter": "^7.22.4",
+        "@microsoft/api-extractor": "^7.34.8",
         "@types/jest": "^29.5.1",
-        "@yext/eslint-config-slapshot": "^0.7.0",
+        "@yext/eslint-config": "^1.0.0",
         "babel-jest": "^29.5.0",
         "eslint": "^8.39.0",
         "jest": "^29.5.0",

--- a/tests/ChatCore.test.ts
+++ b/tests/ChatCore.test.ts
@@ -6,7 +6,7 @@ import { HttpService } from '../src/http/HttpService';
 const emptyMessageRequest: MessageRequest = {
   messages: []
 };
-it('sets default api domain, businessId, version when not specified', async () => {
+it('sets default api domain and businessId when not specified', async () => {
   const httpServiceSpy = jest.spyOn(HttpService.prototype, 'post')
     .mockResolvedValue({
       response: {},
@@ -20,7 +20,7 @@ it('sets default api domain, businessId, version when not specified', async () =
   expect(httpServiceSpy).toHaveBeenCalledWith(
     'https://liveapi.yext.com/v2/accounts/me/chat/my-bot/message',
     { v: defaultApiVersion },
-    { version: 'PRODUCTION', messages: [] },
+    { messages: [] },
     'my-api-key'
   );
 });


### PR DESCRIPTION
Remove bot config version defaulting logic in core. The default will be set in the ChatApiServer.

J=CLIP-109
TEST=auto

see the updated unit test passed. Tested default logic in the CR for ChatApiServer update