### PR TITLE
update timestamp to be string

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ response = await chatCore.getNextMessage({
     {
       source: "USER",
       text: "What is Yext Chat?",
-      timestamp: 1234566789,
+      timestamp: "2023-05-15T17:33:38.373Z",
     },
   ],
 });

--- a/docs/chat-core.message.md
+++ b/docs/chat-core.message.md
@@ -18,5 +18,5 @@ export interface Message
 |  --- | --- | --- | --- |
 |  [source](./chat-core.message.source.md) |  | [EnumOrLiteral](./chat-core.enumorliteral.md)<!-- -->&lt;[MessageSource](./chat-core.messagesource.md)<!-- -->&gt; | The sender of the message. |
 |  [text](./chat-core.message.text.md) |  | string | The message's content. |
-|  [timestamp](./chat-core.message.timestamp.md) |  | number | Time when the message is sent. |
+|  [timestamp](./chat-core.message.timestamp.md) |  | string | Time when the message is sent. |
 

--- a/docs/chat-core.message.timestamp.md
+++ b/docs/chat-core.message.timestamp.md
@@ -9,5 +9,5 @@ Time when the message is sent.
 **Signature:**
 
 ```typescript
-timestamp: number;
+timestamp: string;
 ```

--- a/etc/chat-core.api.md
+++ b/etc/chat-core.api.md
@@ -26,7 +26,7 @@ export type EnumOrLiteral<T extends string> = T | `${T}`;
 export interface Message {
     source: EnumOrLiteral<MessageSource>;
     text: string;
-    timestamp: number;
+    timestamp: string;
 }
 
 // @public

--- a/src/models/endpoints/Message.ts
+++ b/src/models/endpoints/Message.ts
@@ -7,7 +7,7 @@ import { EnumOrLiteral } from "../utils/EnumOrLiteral";
  */
 export interface Message {
   /** Time when the message is sent. */
-  timestamp: number;
+  timestamp: string;
   /** The sender of the message. */
   source: EnumOrLiteral<MessageSource>;
   /** The message's content. */

--- a/test-browser-esm/package-lock.json
+++ b/test-browser-esm/package-lock.json
@@ -36,6 +36,7 @@
         "eslint": "^8.39.0",
         "jest": "^29.5.0",
         "jest-environment-jsdom": "^29.5.0",
+        "prettier": "^2.8.8",
         "typescript": "^5.0.4"
       }
     },

--- a/tests/ChatCore.test.ts
+++ b/tests/ChatCore.test.ts
@@ -55,7 +55,7 @@ it("returns message response on successful API response", async () => {
     message: {
       text: "hello world!",
       source: MessageSource.BOT,
-      timestamp: 123456789,
+      timestamp: "2023-05-15T17:33:38.373Z",
     },
     notes: {
       currentGoal: "test!",


### PR DESCRIPTION
Convert message timestamps back to a date string (ISO8601) since liveapi stringify int64 from Go as it was too big for JS

J=CLIP-130
TEST=compile