### PR TITLE
optional timestamp in Message

### DIFF
--- a/docs/chat-core.message.md
+++ b/docs/chat-core.message.md
@@ -18,5 +18,5 @@ export interface Message
 |  --- | --- | --- | --- |
 |  [source](./chat-core.message.source.md) |  | [EnumOrLiteral](./chat-core.enumorliteral.md)<!-- -->&lt;[MessageSource](./chat-core.messagesource.md)<!-- -->&gt; | The sender of the message. |
 |  [text](./chat-core.message.text.md) |  | string | The message's content. |
-|  [timestamp](./chat-core.message.timestamp.md) |  | string | Time when the message is sent. |
+|  [timestamp?](./chat-core.message.timestamp.md) |  | string | _(Optional)_ Time when the message is sent. |
 

--- a/docs/chat-core.message.timestamp.md
+++ b/docs/chat-core.message.timestamp.md
@@ -9,5 +9,5 @@ Time when the message is sent.
 **Signature:**
 
 ```typescript
-timestamp: string;
+timestamp?: string;
 ```

--- a/etc/chat-core.api.md
+++ b/etc/chat-core.api.md
@@ -26,7 +26,7 @@ export type EnumOrLiteral<T extends string> = T | `${T}`;
 export interface Message {
     source: EnumOrLiteral<MessageSource>;
     text: string;
-    timestamp: string;
+    timestamp?: string;
 }
 
 // @public

--- a/src/models/endpoints/Message.ts
+++ b/src/models/endpoints/Message.ts
@@ -7,7 +7,7 @@ import { EnumOrLiteral } from "../utils/EnumOrLiteral";
  */
 export interface Message {
   /** Time when the message is sent. */
-  timestamp: string;
+  timestamp?: string;
   /** The sender of the message. */
   source: EnumOrLiteral<MessageSource>;
   /** The message's content. */


### PR DESCRIPTION
with streaming API sending timestamp in the final `endEvent` only, this would make `timestamp` field optional in `Message`.