### PR TITLE
Better response error handling from stream endpoint

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@yext/chat-core",
-  "version": "0.3.0",
+  "version": "0.3.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@yext/chat-core",
-      "version": "0.3.0",
+      "version": "0.3.1",
       "license": "BSD-3-Clause",
       "dependencies": {
         "cross-fetch": "^3.1.5"
@@ -138,12 +138,12 @@
       }
     },
     "node_modules/@babel/generator": {
-      "version": "7.21.5",
-      "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.21.5.tgz",
-      "integrity": "sha512-SrKK/sRv8GesIW1bDagf9cCG38IOMYZusoe1dfg0D8aiUe3Amvoj1QtjTPAWcfrZFvIwlleLb0gxzQidL9w14w==",
+      "version": "7.22.3",
+      "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.22.3.tgz",
+      "integrity": "sha512-C17MW4wlk//ES/CJDL51kPNwl+qiBQyN7b9SKyVp11BLGFeSPoVaHrv+MNt8jwQFhQWowW88z1eeBx3pFz9v8A==",
       "dev": true,
       "dependencies": {
-        "@babel/types": "^7.21.5",
+        "@babel/types": "^7.22.3",
         "@jridgewell/gen-mapping": "^0.3.2",
         "@jridgewell/trace-mapping": "^0.3.17",
         "jsesc": "^2.5.1"
@@ -205,17 +205,17 @@
       }
     },
     "node_modules/@babel/helper-create-class-features-plugin": {
-      "version": "7.21.8",
-      "resolved": "https://registry.npmjs.org/@babel/helper-create-class-features-plugin/-/helper-create-class-features-plugin-7.21.8.tgz",
-      "integrity": "sha512-+THiN8MqiH2AczyuZrnrKL6cAxFRRQDKW9h1YkBvbgKmAm6mwiacig1qT73DHIWMGo40GRnsEfN3LA+E6NtmSw==",
+      "version": "7.22.1",
+      "resolved": "https://registry.npmjs.org/@babel/helper-create-class-features-plugin/-/helper-create-class-features-plugin-7.22.1.tgz",
+      "integrity": "sha512-SowrZ9BWzYFgzUMwUmowbPSGu6CXL5MSuuCkG3bejahSpSymioPmuLdhPxNOc9MjuNGjy7M/HaXvJ8G82Lywlw==",
       "dev": true,
       "dependencies": {
         "@babel/helper-annotate-as-pure": "^7.18.6",
-        "@babel/helper-environment-visitor": "^7.21.5",
+        "@babel/helper-environment-visitor": "^7.22.1",
         "@babel/helper-function-name": "^7.21.0",
-        "@babel/helper-member-expression-to-functions": "^7.21.5",
+        "@babel/helper-member-expression-to-functions": "^7.22.0",
         "@babel/helper-optimise-call-expression": "^7.18.6",
-        "@babel/helper-replace-supers": "^7.21.5",
+        "@babel/helper-replace-supers": "^7.22.1",
         "@babel/helper-skip-transparent-expression-wrappers": "^7.20.0",
         "@babel/helper-split-export-declaration": "^7.18.6",
         "semver": "^6.3.0"
@@ -289,9 +289,9 @@
       }
     },
     "node_modules/@babel/helper-environment-visitor": {
-      "version": "7.21.5",
-      "resolved": "https://registry.npmjs.org/@babel/helper-environment-visitor/-/helper-environment-visitor-7.21.5.tgz",
-      "integrity": "sha512-IYl4gZ3ETsWocUWgsFZLM5i1BYx9SoemminVEXadgLBa9TdeorzgLKm8wWLA6J1N/kT3Kch8XIk1laNzYoHKvQ==",
+      "version": "7.22.1",
+      "resolved": "https://registry.npmjs.org/@babel/helper-environment-visitor/-/helper-environment-visitor-7.22.1.tgz",
+      "integrity": "sha512-Z2tgopurB/kTbidvzeBrc2To3PUP/9i5MUe+fU6QJCQDyPwSH2oRapkLw3KGECDYSjhQZCNxEvNvZlLw8JjGwA==",
       "dev": true,
       "engines": {
         "node": ">=6.9.0"
@@ -323,12 +323,12 @@
       }
     },
     "node_modules/@babel/helper-member-expression-to-functions": {
-      "version": "7.21.5",
-      "resolved": "https://registry.npmjs.org/@babel/helper-member-expression-to-functions/-/helper-member-expression-to-functions-7.21.5.tgz",
-      "integrity": "sha512-nIcGfgwpH2u4n9GG1HpStW5Ogx7x7ekiFHbjjFRKXbn5zUvqO9ZgotCO4x1aNbKn/x/xOUaXEhyNHCwtFCpxWg==",
+      "version": "7.22.3",
+      "resolved": "https://registry.npmjs.org/@babel/helper-member-expression-to-functions/-/helper-member-expression-to-functions-7.22.3.tgz",
+      "integrity": "sha512-Gl7sK04b/2WOb6OPVeNy9eFKeD3L6++CzL3ykPOWqTn08xgYYK0wz4TUh2feIImDXxcVW3/9WQ1NMKY66/jfZA==",
       "dev": true,
       "dependencies": {
-        "@babel/types": "^7.21.5"
+        "@babel/types": "^7.22.3"
       },
       "engines": {
         "node": ">=6.9.0"
@@ -405,17 +405,17 @@
       }
     },
     "node_modules/@babel/helper-replace-supers": {
-      "version": "7.21.5",
-      "resolved": "https://registry.npmjs.org/@babel/helper-replace-supers/-/helper-replace-supers-7.21.5.tgz",
-      "integrity": "sha512-/y7vBgsr9Idu4M6MprbOVUfH3vs7tsIfnVWv/Ml2xgwvyH6LTngdfbf5AdsKwkJy4zgy1X/kuNrEKvhhK28Yrg==",
+      "version": "7.22.1",
+      "resolved": "https://registry.npmjs.org/@babel/helper-replace-supers/-/helper-replace-supers-7.22.1.tgz",
+      "integrity": "sha512-ut4qrkE4AuSfrwHSps51ekR1ZY/ygrP1tp0WFm8oVq6nzc/hvfV/22JylndIbsf2U2M9LOMwiSddr6y+78j+OQ==",
       "dev": true,
       "dependencies": {
-        "@babel/helper-environment-visitor": "^7.21.5",
-        "@babel/helper-member-expression-to-functions": "^7.21.5",
+        "@babel/helper-environment-visitor": "^7.22.1",
+        "@babel/helper-member-expression-to-functions": "^7.22.0",
         "@babel/helper-optimise-call-expression": "^7.18.6",
-        "@babel/template": "^7.20.7",
-        "@babel/traverse": "^7.21.5",
-        "@babel/types": "^7.21.5"
+        "@babel/template": "^7.21.9",
+        "@babel/traverse": "^7.22.1",
+        "@babel/types": "^7.22.0"
       },
       "engines": {
         "node": ">=6.9.0"
@@ -599,9 +599,9 @@
       }
     },
     "node_modules/@babel/parser": {
-      "version": "7.21.8",
-      "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.21.8.tgz",
-      "integrity": "sha512-6zavDGdzG3gUqAdWvlLFfk+36RilI+Pwyuuh7HItyeScCWP3k6i8vKclAQ0bM/0y/Kz/xiwvxhMv9MgTJP5gmA==",
+      "version": "7.22.4",
+      "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.22.4.tgz",
+      "integrity": "sha512-VLLsx06XkEYqBtE5YGPwfSGwfrjnyPP5oiGty3S8pQLFDFLaS8VwWSIxkTXpcvr5zeYLE6+MBNl2npl/YnfofA==",
       "dev": true,
       "bin": {
         "parser": "bin/babel-parser.js"
@@ -694,16 +694,16 @@
       }
     },
     "node_modules/@babel/plugin-proposal-decorators": {
-      "version": "7.21.0",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-proposal-decorators/-/plugin-proposal-decorators-7.21.0.tgz",
-      "integrity": "sha512-MfgX49uRrFUTL/HvWtmx3zmpyzMMr4MTj3d527MLlr/4RTT9G/ytFFP7qet2uM2Ve03b+BkpWUpK+lRXnQ+v9w==",
+      "version": "7.22.3",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-proposal-decorators/-/plugin-proposal-decorators-7.22.3.tgz",
+      "integrity": "sha512-XjTKH3sHr6pPqG+hR1NCdVupwiosfdKM2oSMyKQVQ5Bym9l/p7BuLAqT5U32zZzRCfPq/TPRPzMiiTE9bOXU4w==",
       "dev": true,
       "dependencies": {
-        "@babel/helper-create-class-features-plugin": "^7.21.0",
-        "@babel/helper-plugin-utils": "^7.20.2",
-        "@babel/helper-replace-supers": "^7.20.7",
+        "@babel/helper-create-class-features-plugin": "^7.22.1",
+        "@babel/helper-plugin-utils": "^7.21.5",
+        "@babel/helper-replace-supers": "^7.22.1",
         "@babel/helper-split-export-declaration": "^7.18.6",
-        "@babel/plugin-syntax-decorators": "^7.21.0"
+        "@babel/plugin-syntax-decorators": "^7.22.3"
       },
       "engines": {
         "node": ">=6.9.0"
@@ -962,12 +962,12 @@
       }
     },
     "node_modules/@babel/plugin-syntax-decorators": {
-      "version": "7.21.0",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-decorators/-/plugin-syntax-decorators-7.21.0.tgz",
-      "integrity": "sha512-tIoPpGBR8UuM4++ccWN3gifhVvQu7ZizuR1fklhRJrd5ewgbkUS+0KVFeWWxELtn18NTLoW32XV7zyOgIAiz+w==",
+      "version": "7.22.3",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-decorators/-/plugin-syntax-decorators-7.22.3.tgz",
+      "integrity": "sha512-R16Zuge73+8/nLcDjkIpyhi5wIbN7i7fiuLJR8yQX7vPAa/ltUKtd3iLbb4AgP5nrLi91HnNUNosELIGUGH1bg==",
       "dev": true,
       "dependencies": {
-        "@babel/helper-plugin-utils": "^7.20.2"
+        "@babel/helper-plugin-utils": "^7.21.5"
       },
       "engines": {
         "node": ">=6.9.0"
@@ -1596,16 +1596,16 @@
       }
     },
     "node_modules/@babel/plugin-transform-react-jsx": {
-      "version": "7.21.5",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-react-jsx/-/plugin-transform-react-jsx-7.21.5.tgz",
-      "integrity": "sha512-ELdlq61FpoEkHO6gFRpfj0kUgSwQTGoaEU8eMRoS8Dv3v6e7BjEAj5WMtIBRdHUeAioMhKP5HyxNzNnP+heKbA==",
+      "version": "7.22.3",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-react-jsx/-/plugin-transform-react-jsx-7.22.3.tgz",
+      "integrity": "sha512-JEulRWG2f04a7L8VWaOngWiK6p+JOSpB+DAtwfJgOaej1qdbNxqtK7MwTBHjUA10NeFcszlFNqCdbRcirzh2uQ==",
       "dev": true,
       "dependencies": {
         "@babel/helper-annotate-as-pure": "^7.18.6",
         "@babel/helper-module-imports": "^7.21.4",
         "@babel/helper-plugin-utils": "^7.21.5",
         "@babel/plugin-syntax-jsx": "^7.21.4",
-        "@babel/types": "^7.21.5"
+        "@babel/types": "^7.22.3"
       },
       "engines": {
         "node": ">=6.9.0"
@@ -1677,20 +1677,76 @@
       }
     },
     "node_modules/@babel/plugin-transform-runtime": {
-      "version": "7.21.4",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-runtime/-/plugin-transform-runtime-7.21.4.tgz",
-      "integrity": "sha512-1J4dhrw1h1PqnNNpzwxQ2UBymJUF8KuPjAAnlLwZcGhHAIqUigFW7cdK6GHoB64ubY4qXQNYknoUeks4Wz7CUA==",
+      "version": "7.22.4",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-runtime/-/plugin-transform-runtime-7.22.4.tgz",
+      "integrity": "sha512-Urkiz1m4zqiRo17klj+l3nXgiRTFQng91Bc1eiLF7BMQu1e7wE5Gcq9xSv062IF068NHjcutSbIMev60gXxAvA==",
       "dev": true,
       "dependencies": {
         "@babel/helper-module-imports": "^7.21.4",
-        "@babel/helper-plugin-utils": "^7.20.2",
-        "babel-plugin-polyfill-corejs2": "^0.3.3",
-        "babel-plugin-polyfill-corejs3": "^0.6.0",
-        "babel-plugin-polyfill-regenerator": "^0.4.1",
+        "@babel/helper-plugin-utils": "^7.21.5",
+        "babel-plugin-polyfill-corejs2": "^0.4.3",
+        "babel-plugin-polyfill-corejs3": "^0.8.1",
+        "babel-plugin-polyfill-regenerator": "^0.5.0",
         "semver": "^6.3.0"
       },
       "engines": {
         "node": ">=6.9.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0-0"
+      }
+    },
+    "node_modules/@babel/plugin-transform-runtime/node_modules/@babel/helper-define-polyfill-provider": {
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/@babel/helper-define-polyfill-provider/-/helper-define-polyfill-provider-0.4.0.tgz",
+      "integrity": "sha512-RnanLx5ETe6aybRi1cO/edaRH+bNYWaryCEmjDDYyNr4wnSzyOp8T0dWipmqVHKEY3AbVKUom50AKSlj1zmKbg==",
+      "dev": true,
+      "dependencies": {
+        "@babel/helper-compilation-targets": "^7.17.7",
+        "@babel/helper-plugin-utils": "^7.16.7",
+        "debug": "^4.1.1",
+        "lodash.debounce": "^4.0.8",
+        "resolve": "^1.14.2",
+        "semver": "^6.1.2"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.4.0-0"
+      }
+    },
+    "node_modules/@babel/plugin-transform-runtime/node_modules/babel-plugin-polyfill-corejs2": {
+      "version": "0.4.3",
+      "resolved": "https://registry.npmjs.org/babel-plugin-polyfill-corejs2/-/babel-plugin-polyfill-corejs2-0.4.3.tgz",
+      "integrity": "sha512-bM3gHc337Dta490gg+/AseNB9L4YLHxq1nGKZZSHbhXv4aTYU2MD2cjza1Ru4S6975YLTaL1K8uJf6ukJhhmtw==",
+      "dev": true,
+      "dependencies": {
+        "@babel/compat-data": "^7.17.7",
+        "@babel/helper-define-polyfill-provider": "^0.4.0",
+        "semver": "^6.1.1"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0-0"
+      }
+    },
+    "node_modules/@babel/plugin-transform-runtime/node_modules/babel-plugin-polyfill-corejs3": {
+      "version": "0.8.1",
+      "resolved": "https://registry.npmjs.org/babel-plugin-polyfill-corejs3/-/babel-plugin-polyfill-corejs3-0.8.1.tgz",
+      "integrity": "sha512-ikFrZITKg1xH6pLND8zT14UPgjKHiGLqex7rGEZCH2EvhsneJaJPemmpQaIZV5AL03II+lXylw3UmddDK8RU5Q==",
+      "dev": true,
+      "dependencies": {
+        "@babel/helper-define-polyfill-provider": "^0.4.0",
+        "core-js-compat": "^3.30.1"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0-0"
+      }
+    },
+    "node_modules/@babel/plugin-transform-runtime/node_modules/babel-plugin-polyfill-regenerator": {
+      "version": "0.5.0",
+      "resolved": "https://registry.npmjs.org/babel-plugin-polyfill-regenerator/-/babel-plugin-polyfill-regenerator-0.5.0.tgz",
+      "integrity": "sha512-hDJtKjMLVa7Z+LwnTCxoDLQj6wdc+B8dun7ayF2fYieI6OzfuvcLMB32ihJZ4UhCBwNYGl5bg/x/P9cMdnkc2g==",
+      "dev": true,
+      "dependencies": {
+        "@babel/helper-define-polyfill-provider": "^0.4.0"
       },
       "peerDependencies": {
         "@babel/core": "^7.0.0-0"
@@ -1946,15 +2002,15 @@
       }
     },
     "node_modules/@babel/preset-react": {
-      "version": "7.18.6",
-      "resolved": "https://registry.npmjs.org/@babel/preset-react/-/preset-react-7.18.6.tgz",
-      "integrity": "sha512-zXr6atUmyYdiWRVLOZahakYmOBHtWc2WGCkP8PYTgZi0iJXDY2CN180TdrIW4OGOAdLc7TifzDIvtx6izaRIzg==",
+      "version": "7.22.3",
+      "resolved": "https://registry.npmjs.org/@babel/preset-react/-/preset-react-7.22.3.tgz",
+      "integrity": "sha512-lxDz1mnZ9polqClBCVBjIVUypoB4qV3/tZUDb/IlYbW1kiiLaXaX+bInbRjl+lNQ/iUZraQ3+S8daEmoELMWug==",
       "dev": true,
       "dependencies": {
-        "@babel/helper-plugin-utils": "^7.18.6",
-        "@babel/helper-validator-option": "^7.18.6",
+        "@babel/helper-plugin-utils": "^7.21.5",
+        "@babel/helper-validator-option": "^7.21.0",
         "@babel/plugin-transform-react-display-name": "^7.18.6",
-        "@babel/plugin-transform-react-jsx": "^7.18.6",
+        "@babel/plugin-transform-react-jsx": "^7.22.3",
         "@babel/plugin-transform-react-jsx-development": "^7.18.6",
         "@babel/plugin-transform-react-pure-annotations": "^7.18.6"
       },
@@ -2003,33 +2059,33 @@
       }
     },
     "node_modules/@babel/template": {
-      "version": "7.20.7",
-      "resolved": "https://registry.npmjs.org/@babel/template/-/template-7.20.7.tgz",
-      "integrity": "sha512-8SegXApWe6VoNw0r9JHpSteLKTpTiLZ4rMlGIm9JQ18KiCtyQiAMEazujAHrUS5flrcqYZa75ukev3P6QmUwUw==",
+      "version": "7.21.9",
+      "resolved": "https://registry.npmjs.org/@babel/template/-/template-7.21.9.tgz",
+      "integrity": "sha512-MK0X5k8NKOuWRamiEfc3KEJiHMTkGZNUjzMipqCGDDc6ijRl/B7RGSKVGncu4Ro/HdyzzY6cmoXuKI2Gffk7vQ==",
       "dev": true,
       "dependencies": {
-        "@babel/code-frame": "^7.18.6",
-        "@babel/parser": "^7.20.7",
-        "@babel/types": "^7.20.7"
+        "@babel/code-frame": "^7.21.4",
+        "@babel/parser": "^7.21.9",
+        "@babel/types": "^7.21.5"
       },
       "engines": {
         "node": ">=6.9.0"
       }
     },
     "node_modules/@babel/traverse": {
-      "version": "7.21.5",
-      "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.21.5.tgz",
-      "integrity": "sha512-AhQoI3YjWi6u/y/ntv7k48mcrCXmus0t79J9qPNlk/lAsFlCiJ047RmbfMOawySTHtywXhbXgpx/8nXMYd+oFw==",
+      "version": "7.22.4",
+      "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.22.4.tgz",
+      "integrity": "sha512-Tn1pDsjIcI+JcLKq1AVlZEr4226gpuAQTsLMorsYg9tuS/kG7nuwwJ4AB8jfQuEgb/COBwR/DqJxmoiYFu5/rQ==",
       "dev": true,
       "dependencies": {
         "@babel/code-frame": "^7.21.4",
-        "@babel/generator": "^7.21.5",
-        "@babel/helper-environment-visitor": "^7.21.5",
+        "@babel/generator": "^7.22.3",
+        "@babel/helper-environment-visitor": "^7.22.1",
         "@babel/helper-function-name": "^7.21.0",
         "@babel/helper-hoist-variables": "^7.18.6",
         "@babel/helper-split-export-declaration": "^7.18.6",
-        "@babel/parser": "^7.21.5",
-        "@babel/types": "^7.21.5",
+        "@babel/parser": "^7.22.4",
+        "@babel/types": "^7.22.4",
         "debug": "^4.1.0",
         "globals": "^11.1.0"
       },
@@ -2047,9 +2103,9 @@
       }
     },
     "node_modules/@babel/types": {
-      "version": "7.21.5",
-      "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.21.5.tgz",
-      "integrity": "sha512-m4AfNvVF2mVC/F7fDEdH2El3HzUg9It/XsCxZiOTTA3m3qYfcSVSbTfM6Q9xG+hYDniZssYhlXKKUMD5m8tF4Q==",
+      "version": "7.22.4",
+      "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.22.4.tgz",
+      "integrity": "sha512-Tx9x3UBHTTsMSW85WB2kphxYQVvrZ/t1FxD88IpSgIjiUJlCm9z+xWIDwyo1vffTwSqteqyznB8ZE9vYYk16zA==",
       "dev": true,
       "dependencies": {
         "@babel/helper-string-parser": "^7.21.5",
@@ -2819,9 +2875,9 @@
       }
     },
     "node_modules/@rushstack/eslint-patch": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/@rushstack/eslint-patch/-/eslint-patch-1.2.0.tgz",
-      "integrity": "sha512-sXo/qW2/pAcmT43VoRKOJbDOfV3cYpq3szSVfIThQXNt+E4DfKj361vaAt3c88U5tPUxzEswam7GW48PJqtKAg==",
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/@rushstack/eslint-patch/-/eslint-patch-1.3.0.tgz",
+      "integrity": "sha512-IthPJsJR85GhOkp3Hvp8zFOPK5ynKn6STyHa/WZpioK7E1aYDiBzpqQPrngc14DszIUkIrdd3k9Iu0XSzlP/1w==",
       "dev": true
     },
     "node_modules/@rushstack/node-core-library": {
@@ -3046,9 +3102,9 @@
       }
     },
     "node_modules/@types/json-schema": {
-      "version": "7.0.11",
-      "resolved": "https://registry.npmjs.org/@types/json-schema/-/json-schema-7.0.11.tgz",
-      "integrity": "sha512-wOuvG1SN4Us4rez+tylwwwCV1psiNVOkJeM3AUWUNWg/jDQY2+HE/444y5gc+jBmRqASOm2Oeh5c1axHobwRKQ==",
+      "version": "7.0.12",
+      "resolved": "https://registry.npmjs.org/@types/json-schema/-/json-schema-7.0.12.tgz",
+      "integrity": "sha512-Hr5Jfhc9eYOQNPYO5WLDq/n4jqijdHNlDXjuAQkkt+mWdQR+XJToOHrsD4cPaMXpn6KO7y2+wM8AZEs8VpBLVA==",
       "dev": true
     },
     "node_modules/@types/json5": {
@@ -3100,9 +3156,9 @@
       "dev": true
     },
     "node_modules/@types/semver": {
-      "version": "7.3.13",
-      "resolved": "https://registry.npmjs.org/@types/semver/-/semver-7.3.13.tgz",
-      "integrity": "sha512-21cFJr9z3g5dW8B0CVI9g2O9beqaThGQ6ZFBqHfwhzLDKUxaqTIy3vnfah/UPkfOiF2pLq+tGz+W8RyCskuslw==",
+      "version": "7.5.0",
+      "resolved": "https://registry.npmjs.org/@types/semver/-/semver-7.5.0.tgz",
+      "integrity": "sha512-G8hZ6XJiHnuhQKR7ZmysCeJWE08o8T0AXtk5darsCaTVsYZhhgUrq53jizaR2FvsoeCwJhlmwTjkXBY5Pn/ZHw==",
       "dev": true
     },
     "node_modules/@types/stack-utils": {
@@ -3133,15 +3189,15 @@
       "dev": true
     },
     "node_modules/@typescript-eslint/eslint-plugin": {
-      "version": "5.59.2",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-5.59.2.tgz",
-      "integrity": "sha512-yVrXupeHjRxLDcPKL10sGQ/QlVrA8J5IYOEWVqk0lJaSZP7X5DfnP7Ns3cc74/blmbipQ1htFNVGsHX6wsYm0A==",
+      "version": "5.59.9",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-5.59.9.tgz",
+      "integrity": "sha512-4uQIBq1ffXd2YvF7MAvehWKW3zVv/w+mSfRAu+8cKbfj3nwzyqJLNcZJpQ/WZ1HLbJDiowwmQ6NO+63nCA+fqA==",
       "dev": true,
       "dependencies": {
         "@eslint-community/regexpp": "^4.4.0",
-        "@typescript-eslint/scope-manager": "5.59.2",
-        "@typescript-eslint/type-utils": "5.59.2",
-        "@typescript-eslint/utils": "5.59.2",
+        "@typescript-eslint/scope-manager": "5.59.9",
+        "@typescript-eslint/type-utils": "5.59.9",
+        "@typescript-eslint/utils": "5.59.9",
         "debug": "^4.3.4",
         "grapheme-splitter": "^1.0.4",
         "ignore": "^5.2.0",
@@ -3167,12 +3223,12 @@
       }
     },
     "node_modules/@typescript-eslint/experimental-utils": {
-      "version": "5.59.2",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/experimental-utils/-/experimental-utils-5.59.2.tgz",
-      "integrity": "sha512-JLw2UImsjHDuVukpA8Nt+UK7JKE/LQAeV3tU5f7wJo2/NNYVwcakzkWjoYzu/2qzWY/Z9c7zojngNDfecNt92g==",
+      "version": "5.59.9",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/experimental-utils/-/experimental-utils-5.59.9.tgz",
+      "integrity": "sha512-eZTK/Ci0QAqNc/q2MqMwI2+QI5ZI9HM12FcfGwbEvKif5ev/CIIYLmrlckvgPrC8XSbl39HtErR5NJiQkRkvWg==",
       "dev": true,
       "dependencies": {
-        "@typescript-eslint/utils": "5.59.2"
+        "@typescript-eslint/utils": "5.59.9"
       },
       "engines": {
         "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
@@ -3186,14 +3242,14 @@
       }
     },
     "node_modules/@typescript-eslint/parser": {
-      "version": "5.59.2",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-5.59.2.tgz",
-      "integrity": "sha512-uq0sKyw6ao1iFOZZGk9F8Nro/8+gfB5ezl1cA06SrqbgJAt0SRoFhb9pXaHvkrxUpZaoLxt8KlovHNk8Gp6/HQ==",
+      "version": "5.59.9",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-5.59.9.tgz",
+      "integrity": "sha512-FsPkRvBtcLQ/eVK1ivDiNYBjn3TGJdXy2fhXX+rc7czWl4ARwnpArwbihSOHI2Peg9WbtGHrbThfBUkZZGTtvQ==",
       "dev": true,
       "dependencies": {
-        "@typescript-eslint/scope-manager": "5.59.2",
-        "@typescript-eslint/types": "5.59.2",
-        "@typescript-eslint/typescript-estree": "5.59.2",
+        "@typescript-eslint/scope-manager": "5.59.9",
+        "@typescript-eslint/types": "5.59.9",
+        "@typescript-eslint/typescript-estree": "5.59.9",
         "debug": "^4.3.4"
       },
       "engines": {
@@ -3213,13 +3269,13 @@
       }
     },
     "node_modules/@typescript-eslint/scope-manager": {
-      "version": "5.59.2",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-5.59.2.tgz",
-      "integrity": "sha512-dB1v7ROySwQWKqQ8rEWcdbTsFjh2G0vn8KUyvTXdPoyzSL6lLGkiXEV5CvpJsEe9xIdKV+8Zqb7wif2issoOFA==",
+      "version": "5.59.9",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-5.59.9.tgz",
+      "integrity": "sha512-8RA+E+w78z1+2dzvK/tGZ2cpGigBZ58VMEHDZtpE1v+LLjzrYGc8mMaTONSxKyEkz3IuXFM0IqYiGHlCsmlZxQ==",
       "dev": true,
       "dependencies": {
-        "@typescript-eslint/types": "5.59.2",
-        "@typescript-eslint/visitor-keys": "5.59.2"
+        "@typescript-eslint/types": "5.59.9",
+        "@typescript-eslint/visitor-keys": "5.59.9"
       },
       "engines": {
         "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
@@ -3230,13 +3286,13 @@
       }
     },
     "node_modules/@typescript-eslint/type-utils": {
-      "version": "5.59.2",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/type-utils/-/type-utils-5.59.2.tgz",
-      "integrity": "sha512-b1LS2phBOsEy/T381bxkkywfQXkV1dWda/z0PhnIy3bC5+rQWQDS7fk9CSpcXBccPY27Z6vBEuaPBCKCgYezyQ==",
+      "version": "5.59.9",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/type-utils/-/type-utils-5.59.9.tgz",
+      "integrity": "sha512-ksEsT0/mEHg9e3qZu98AlSrONAQtrSTljL3ow9CGej8eRo7pe+yaC/mvTjptp23Xo/xIf2mLZKC6KPv4Sji26Q==",
       "dev": true,
       "dependencies": {
-        "@typescript-eslint/typescript-estree": "5.59.2",
-        "@typescript-eslint/utils": "5.59.2",
+        "@typescript-eslint/typescript-estree": "5.59.9",
+        "@typescript-eslint/utils": "5.59.9",
         "debug": "^4.3.4",
         "tsutils": "^3.21.0"
       },
@@ -3257,9 +3313,9 @@
       }
     },
     "node_modules/@typescript-eslint/types": {
-      "version": "5.59.2",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-5.59.2.tgz",
-      "integrity": "sha512-LbJ/HqoVs2XTGq5shkiKaNTuVv5tTejdHgfdjqRUGdYhjW1crm/M7og2jhVskMt8/4wS3T1+PfFvL1K3wqYj4w==",
+      "version": "5.59.9",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-5.59.9.tgz",
+      "integrity": "sha512-uW8H5NRgTVneSVTfiCVffBb8AbwWSKg7qcA4Ot3JI3MPCJGsB4Db4BhvAODIIYE5mNj7Q+VJkK7JxmRhk2Lyjw==",
       "dev": true,
       "engines": {
         "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
@@ -3270,13 +3326,13 @@
       }
     },
     "node_modules/@typescript-eslint/typescript-estree": {
-      "version": "5.59.2",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-5.59.2.tgz",
-      "integrity": "sha512-+j4SmbwVmZsQ9jEyBMgpuBD0rKwi9RxRpjX71Brr73RsYnEr3Lt5QZ624Bxphp8HUkSKfqGnPJp1kA5nl0Sh7Q==",
+      "version": "5.59.9",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-5.59.9.tgz",
+      "integrity": "sha512-pmM0/VQ7kUhd1QyIxgS+aRvMgw+ZljB3eDb+jYyp6d2bC0mQWLzUDF+DLwCTkQ3tlNyVsvZRXjFyV0LkU/aXjA==",
       "dev": true,
       "dependencies": {
-        "@typescript-eslint/types": "5.59.2",
-        "@typescript-eslint/visitor-keys": "5.59.2",
+        "@typescript-eslint/types": "5.59.9",
+        "@typescript-eslint/visitor-keys": "5.59.9",
         "debug": "^4.3.4",
         "globby": "^11.1.0",
         "is-glob": "^4.0.3",
@@ -3297,17 +3353,17 @@
       }
     },
     "node_modules/@typescript-eslint/utils": {
-      "version": "5.59.2",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/utils/-/utils-5.59.2.tgz",
-      "integrity": "sha512-kSuF6/77TZzyGPhGO4uVp+f0SBoYxCDf+lW3GKhtKru/L8k/Hd7NFQxyWUeY7Z/KGB2C6Fe3yf2vVi4V9TsCSQ==",
+      "version": "5.59.9",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/utils/-/utils-5.59.9.tgz",
+      "integrity": "sha512-1PuMYsju/38I5Ggblaeb98TOoUvjhRvLpLa1DoTOFaLWqaXl/1iQ1eGurTXgBY58NUdtfTXKP5xBq7q9NDaLKg==",
       "dev": true,
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.2.0",
         "@types/json-schema": "^7.0.9",
         "@types/semver": "^7.3.12",
-        "@typescript-eslint/scope-manager": "5.59.2",
-        "@typescript-eslint/types": "5.59.2",
-        "@typescript-eslint/typescript-estree": "5.59.2",
+        "@typescript-eslint/scope-manager": "5.59.9",
+        "@typescript-eslint/types": "5.59.9",
+        "@typescript-eslint/typescript-estree": "5.59.9",
         "eslint-scope": "^5.1.1",
         "semver": "^7.3.7"
       },
@@ -3345,12 +3401,12 @@
       }
     },
     "node_modules/@typescript-eslint/visitor-keys": {
-      "version": "5.59.2",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-5.59.2.tgz",
-      "integrity": "sha512-EEpsO8m3RASrKAHI9jpavNv9NlEUebV4qmF1OWxSTtKSFBpC1NCmWazDQHFivRf0O1DV11BA645yrLEVQ0/Lig==",
+      "version": "5.59.9",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-5.59.9.tgz",
+      "integrity": "sha512-bT7s0td97KMaLwpEBckbzj/YohnvXtqbe2XgqNvTl6RJVakY5mvENOTPvw5u66nljfZxthESpDozs86U+oLY8Q==",
       "dev": true,
       "dependencies": {
-        "@typescript-eslint/types": "5.59.2",
+        "@typescript-eslint/types": "5.59.9",
         "eslint-visitor-keys": "^3.3.0"
       },
       "engines": {
@@ -3697,9 +3753,9 @@
       }
     },
     "node_modules/axe-core": {
-      "version": "4.7.0",
-      "resolved": "https://registry.npmjs.org/axe-core/-/axe-core-4.7.0.tgz",
-      "integrity": "sha512-M0JtH+hlOL5pLQwHOLNYZaXuhqmvS8oExsqB1SBYgA4Dk7u/xx+YdGHXaK5pyUfed5mYXdlYiphWq3G8cRi5JQ==",
+      "version": "4.7.2",
+      "resolved": "https://registry.npmjs.org/axe-core/-/axe-core-4.7.2.tgz",
+      "integrity": "sha512-zIURGIS1E1Q4pcrMjp+nnEh+16G56eG/MUllJH8yEvw7asDo7Ac9uhC9KIH5jzpITueEZolfYglnCGIuSBz39g==",
       "dev": true,
       "engines": {
         "node": ">=4"
@@ -5247,9 +5303,9 @@
       }
     },
     "node_modules/eslint-plugin-testing-library": {
-      "version": "5.10.3",
-      "resolved": "https://registry.npmjs.org/eslint-plugin-testing-library/-/eslint-plugin-testing-library-5.10.3.tgz",
-      "integrity": "sha512-0yhsKFsjHLud5PM+f2dWr9K3rqYzMy4cSHs3lcmFYMa1CdSzRvHGgXvsFarBjZ41gU8jhTdMIkg8jHLxGJqLqw==",
+      "version": "5.11.0",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-testing-library/-/eslint-plugin-testing-library-5.11.0.tgz",
+      "integrity": "sha512-ELY7Gefo+61OfXKlQeXNIDVVLPcvKTeiQOoMZG9TeuWa7Ln4dUNRv8JdRWBQI9Mbb427XGlVB1aa1QPZxBJM8Q==",
       "dev": true,
       "dependencies": {
         "@typescript-eslint/utils": "^5.58.0"
@@ -5688,13 +5744,14 @@
       }
     },
     "node_modules/get-intrinsic": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/get-intrinsic/-/get-intrinsic-1.2.0.tgz",
-      "integrity": "sha512-L049y6nFOuom5wGyRc3/gdTLO94dySVKRACj1RmJZBQXlbTMhtNIgkWkUHq+jYmZvKf14EW1EoJnnjbmoHij0Q==",
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/get-intrinsic/-/get-intrinsic-1.2.1.tgz",
+      "integrity": "sha512-2DcsyfABl+gVHEfCOaTrWgyt+tb6MSEGmKq+kI5HwLbIYgjgmMcV8KQ41uaKz1xxUcn9tJtgFbQUEVcEbd0FYw==",
       "dev": true,
       "dependencies": {
         "function-bind": "^1.1.1",
         "has": "^1.0.3",
+        "has-proto": "^1.0.1",
         "has-symbols": "^1.0.3"
       },
       "funding": {

--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
   ],
   "scripts": {
     "test": "jest --config=jest.config.json",
-    "autofix": "prettier --write . && eslint --fix --max-warnings=0 .",
+    "lint": "prettier --write . && eslint --fix --max-warnings=0 .",
     "tsc-cjs": "tsc -p tsconfig.cjs.json",
     "tsc-esm": "tsc -p tsconfig.esm.json",
     "dev": "npm run tsc-esm -- --watch",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@yext/chat-core",
-  "version": "0.3.0",
+  "version": "0.3.1",
   "description": "Typescript Networking Library for the Yext Chat API",
   "main": "./dist/commonjs/index.js",
   "module": "./dist/esm/index.js",

--- a/src/ChatCore.ts
+++ b/src/ChatCore.ts
@@ -13,7 +13,6 @@ import { ApiResponseValidator } from "./validation/ApiResponseValidator";
  * @public
  */
 export class ChatCore {
-
   private chatConfig: ChatConfig;
   private httpService: HttpService;
 
@@ -59,7 +58,9 @@ export class ChatCore {
       const validationResult = ApiResponseValidator.validate(jsonResponse);
       return validationResult instanceof Error
         ? Promise.reject(validationResult)
-        : Promise.reject("An error occurred while processing request to Chat API.")
+        : Promise.reject(
+            "An error occurred while processing request to Chat API."
+          );
     }
     return this.createMessageResponse(jsonResponse);
   }

--- a/src/ChatCore.ts
+++ b/src/ChatCore.ts
@@ -13,15 +13,13 @@ import { ApiResponseValidator } from "./validation/ApiResponseValidator";
  * @public
  */
 export class ChatCore {
-  private chatConfig: ChatConfig;
 
+  private chatConfig: ChatConfig;
   private httpService: HttpService;
-  private apiResponseValidator: ApiResponseValidator;
 
   constructor(chatConfig: ChatConfig) {
     this.chatConfig = chatConfig;
     this.httpService = new HttpService();
-    this.apiResponseValidator = new ApiResponseValidator();
   }
 
   private getUrl({ businessId, botId, apiDomain }: ChatConfig) {
@@ -57,9 +55,11 @@ export class ChatCore {
       this.chatConfig.apiKey
     );
     const jsonResponse: ApiResponse = await rawResponse.json();
-    const validationResult = this.apiResponseValidator.validate(jsonResponse);
-    if (validationResult instanceof Error) {
-      return Promise.reject(validationResult);
+    if (!rawResponse.ok) {
+      const validationResult = ApiResponseValidator.validate(jsonResponse);
+      return validationResult instanceof Error
+        ? Promise.reject(validationResult)
+        : Promise.reject("An error occurred while processing request to Chat API.")
     }
     return this.createMessageResponse(jsonResponse);
   }

--- a/src/infra/StreamResponse.ts
+++ b/src/infra/StreamResponse.ts
@@ -64,15 +64,17 @@ export class StreamResponse {
     }
     const resBody = this.rawResponse.body;
     if (!resBody) {
-      return Promise.reject("Response Error: \"body\" property is undefined.");
+      return Promise.reject('Response Error: "body" property is undefined.');
     }
-    
+
     if (!this.rawResponse.ok) {
       const jsonResponse: ApiResponse = await this.rawResponse.json();
       const validationResult = ApiResponseValidator.validate(jsonResponse);
       return validationResult instanceof Error
         ? Promise.reject(validationResult)
-        : Promise.reject("An error occurred while processing request to Chat API.")
+        : Promise.reject(
+            "An error occurred while processing request to Chat API."
+          );
     }
 
     const streamCompleted =

--- a/src/validation/ApiResponseValidator.ts
+++ b/src/validation/ApiResponseValidator.ts
@@ -20,7 +20,9 @@ export class ApiResponseValidator {
     }
   }
 
-  private static validateResponseProp(apiResponse: ApiResponse): Error | undefined {
+  private static validateResponseProp(
+    apiResponse: ApiResponse
+  ): Error | undefined {
     if (!apiResponse.response) {
       return new Error(
         "Malformed Chat API response: missing response property."
@@ -34,7 +36,9 @@ export class ApiResponseValidator {
     }
   }
 
-  private static checkForApiErrors(apiResponse: ApiResponse): Error | undefined {
+  private static checkForApiErrors(
+    apiResponse: ApiResponse
+  ): Error | undefined {
     if (apiResponse.meta?.errors?.length >= 1) {
       const error = apiResponse.meta.errors[0];
       const { code, message, type } = error;

--- a/src/validation/ApiResponseValidator.ts
+++ b/src/validation/ApiResponseValidator.ts
@@ -6,7 +6,7 @@ import { ApiResponse } from "../models/http/ApiResponse";
  * @internal
  */
 export class ApiResponseValidator {
-  public validate(apiResponse: ApiResponse): Error | undefined {
+  public static validate(apiResponse: ApiResponse): Error | undefined {
     const tests = [
       this.validateResponseProp,
       this.validateMetaProp,
@@ -20,7 +20,7 @@ export class ApiResponseValidator {
     }
   }
 
-  private validateResponseProp(apiResponse: ApiResponse): Error | undefined {
+  private static validateResponseProp(apiResponse: ApiResponse): Error | undefined {
     if (!apiResponse.response) {
       return new Error(
         "Malformed Chat API response: missing response property."
@@ -28,13 +28,13 @@ export class ApiResponseValidator {
     }
   }
 
-  private validateMetaProp(apiResponse: ApiResponse): Error | undefined {
+  private static validateMetaProp(apiResponse: ApiResponse): Error | undefined {
     if (!apiResponse.meta) {
       return new Error("Malformed Chat API response: missing meta property.");
     }
   }
 
-  private checkForApiErrors(apiResponse: ApiResponse): Error | undefined {
+  private static checkForApiErrors(apiResponse: ApiResponse): Error | undefined {
     if (apiResponse.meta?.errors?.length >= 1) {
       const error = apiResponse.meta.errors[0];
       const { code, message, type } = error;

--- a/test-browser-esm/src/script.js
+++ b/test-browser-esm/src/script.js
@@ -3,7 +3,7 @@ import { ChatCore, StreamEventName } from "@yext/chat-core";
 let chatCore = new ChatCore({
   // will be replace with actual env value during rollup build process
   apiKey: process.env.TEST_BOT_API_KEY || "API_KEY_PLACEHOLDER",
-  botId: "red-dog-bot",
+  botId: "tripp-bot",
   apiDomain: "liveapi-dev.yext.com",
 });
 

--- a/tests/ChatCore.test.ts
+++ b/tests/ChatCore.test.ts
@@ -12,9 +12,11 @@ const mockedMessageRequest: MessageRequest = {
 };
 
 function mockHttpPost(
-  expectedResponse: unknown = { response: {}, meta: {} }
+  expectedResponse: unknown = { response: {}, meta: {} },
+  ok = true
 ): jest.SpyInstance {
   return jest.spyOn(HttpService.prototype, "post").mockResolvedValue({
+    ok,
     json: () => Promise.resolve(expectedResponse),
   } as Response);
 }
@@ -58,7 +60,7 @@ it("returns rejected promise on a failed API response", async () => {
         },
       ],
     },
-  });
+  }, false);
   const chatCore = new ChatCore({
     botId: "my-bot",
     apiKey: "my-api-key",

--- a/tests/ChatCore.test.ts
+++ b/tests/ChatCore.test.ts
@@ -49,18 +49,21 @@ it("returns message response on successful API response", async () => {
 });
 
 it("returns rejected promise on a failed API response", async () => {
-  mockHttpPost({
-    response: {},
-    meta: {
-      errors: [
-        {
-          message: "Invalid API Key",
-          code: 1,
-          type: "FATAL_ERROR",
-        },
-      ],
+  mockHttpPost(
+    {
+      response: {},
+      meta: {
+        errors: [
+          {
+            message: "Invalid API Key",
+            code: 1,
+            type: "FATAL_ERROR",
+          },
+        ],
+      },
     },
-  }, false);
+    false
+  );
   const chatCore = new ChatCore({
     botId: "my-bot",
     apiKey: "my-api-key",

--- a/tests/infra/StreamResponse.test.ts
+++ b/tests/infra/StreamResponse.test.ts
@@ -173,14 +173,16 @@ it("rejects when response have a non-successful status code", async () => {
           type: "FATAL_ERROR",
         },
       ],
-    }
-  }
+    },
+  };
   const stream = new StreamResponse({
     ok: false,
     body: {},
-    json: () => Promise.resolve(expectedResponse)
+    json: () => Promise.resolve(expectedResponse),
   } as unknown as RawResponse);
-  await expect(stream.consume()).rejects.toThrow("Chat API error: FATAL_ERROR: Invalid API Key. (code: 1)");
+  await expect(stream.consume()).rejects.toThrow(
+    "Chat API error: FATAL_ERROR: Invalid API Key. (code: 1)"
+  );
 });
 
 it("rejects when error occurs while reading Web stream from response", async () => {

--- a/tests/infra/StreamResponse.test.ts
+++ b/tests/infra/StreamResponse.test.ts
@@ -1,8 +1,10 @@
 import { RawResponse, StreamEventName, StreamResponse } from "../../src";
 import { Readable } from "stream";
+import { ApiResponse } from "../../src/models/http/ApiResponse";
 
 function mockResponse(rawData: string[]): RawResponse {
   return {
+    ok: true,
     body: {
       getReader: () => {
         let i = -1;
@@ -23,6 +25,7 @@ function mockResponse(rawData: string[]): RawResponse {
 
 function mockNodeResponse(rawData: string[]): RawResponse {
   return {
+    ok: true,
     body: new Readable({
       read() {
         rawData.forEach((d) => this.push(d));
@@ -158,8 +161,31 @@ it("log error when attempt to read stream data multiple times", async () => {
   );
 });
 
+it("rejects when response have a non-successful status code", async () => {
+  const expectedResponse: ApiResponse = {
+    response: {},
+    meta: {
+      uuid: "test",
+      errors: [
+        {
+          message: "Invalid API Key",
+          code: 1,
+          type: "FATAL_ERROR",
+        },
+      ],
+    }
+  }
+  const stream = new StreamResponse({
+    ok: false,
+    body: {},
+    json: () => Promise.resolve(expectedResponse)
+  } as unknown as RawResponse);
+  await expect(stream.consume()).rejects.toThrow("Chat API error: FATAL_ERROR: Invalid API Key. (code: 1)");
+});
+
 it("rejects when error occurs while reading Web stream from response", async () => {
   const stream = new StreamResponse({
+    ok: true,
     body: {
       getReader: () => {
         return {
@@ -175,6 +201,7 @@ it("rejects when error occurs while reading Web stream from response", async () 
 
 it("rejects when error occurs while reading Node stream from response", async () => {
   const stream = new StreamResponse({
+    ok: true,
     body: new Readable({
       read() {
         throw Error("Unable to read data");

--- a/tests/validation/ApiResponseValidator.test.ts
+++ b/tests/validation/ApiResponseValidator.test.ts
@@ -1,8 +1,6 @@
 import { ApiResponseValidator } from "../../src/validation/ApiResponseValidator";
 import { ApiResponse } from "../../src/models/http/ApiResponse";
 
-const apiResponseValidator = new ApiResponseValidator();
-
 it("passes for a response with no errors", () => {
   const response = {
     response: {},
@@ -11,7 +9,7 @@ it("passes for a response with no errors", () => {
       errors: [],
     },
   };
-  const validationResponse = apiResponseValidator.validate(response);
+  const validationResponse = ApiResponseValidator.validate(response);
   expect(validationResponse).toBeUndefined();
 });
 
@@ -22,7 +20,7 @@ it("fails for a response without a response property", () => {
       errors: [],
     },
   } as unknown as ApiResponse;
-  const validationResponse = apiResponseValidator.validate(response);
+  const validationResponse = ApiResponseValidator.validate(response);
   expect(validationResponse).toBeInstanceOf(Error);
   expect(validationResponse?.message).toEqual(
     "Malformed Chat API response: missing response property."
@@ -33,7 +31,7 @@ it("fails for a response without a meta property", () => {
   const response = {
     response: {},
   } as ApiResponse;
-  const validationResponse = apiResponseValidator.validate(response);
+  const validationResponse = ApiResponseValidator.validate(response);
   expect(validationResponse).toBeInstanceOf(Error);
   expect(validationResponse?.message).toEqual(
     "Malformed Chat API response: missing meta property."
@@ -54,7 +52,7 @@ it("fails for a response with an API error", () => {
       ],
     },
   };
-  const validationResponse = apiResponseValidator.validate(response);
+  const validationResponse = ApiResponseValidator.validate(response);
   expect(validationResponse).toBeInstanceOf(Error);
   expect(validationResponse?.message).toEqual(
     "Chat API error: FATAL_ERROR: Invalid API Key. (code: 1)"


### PR DESCRIPTION
- when response from streaming api returned a non-successful status code, immediately rejects promise with the error in response's body

J=CLIP-206
TEST=manual&auto

see that added jest tests passed
see that it returned proper uncaught promise error in browser console from test site