### PR TITLE
optional conversationId in MessageResponse

### DIFF
--- a/docs/chat-core.messageresponse.conversationid.md
+++ b/docs/chat-core.messageresponse.conversationid.md
@@ -9,5 +9,10 @@ The id corresponds to the current conversation.
 **Signature:**
 
 ```typescript
-conversationId: string;
+conversationId?: string;
 ```
+
+## Remarks
+
+This is undefined only when it's an initial bot response without any user message present.
+

--- a/docs/chat-core.messageresponse.md
+++ b/docs/chat-core.messageresponse.md
@@ -16,7 +16,7 @@ export interface MessageResponse
 
 |  Property | Modifiers | Type | Description |
 |  --- | --- | --- | --- |
-|  [conversationId](./chat-core.messageresponse.conversationid.md) |  | string | The id corresponds to the current conversation. |
+|  [conversationId?](./chat-core.messageresponse.conversationid.md) |  | string | _(Optional)_ The id corresponds to the current conversation. |
 |  [message](./chat-core.messageresponse.message.md) |  | [Message](./chat-core.message.md) | The generated reply to the latest message in the request. |
 |  [notes](./chat-core.messageresponse.notes.md) |  | [MessageNotes](./chat-core.messagenotes.md) | Information relevant to the current state of the conversation, serving as the bot’s "memory" regarding what work it previously did to help determine future actions. |
 

--- a/etc/chat-core.api.md
+++ b/etc/chat-core.api.md
@@ -80,7 +80,7 @@ export interface MessageRequest {
 
 // @public
 export interface MessageResponse {
-    conversationId: string;
+    conversationId?: string;
     message: Message;
     notes: MessageNotes;
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@yext/chat-core",
-  "version": "0.5.4",
+  "version": "0.5.5",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@yext/chat-core",
-      "version": "0.5.4",
+      "version": "0.5.5",
       "license": "BSD-3-Clause",
       "dependencies": {
         "cross-fetch": "^3.1.5"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@yext/chat-core",
-  "version": "0.5.4",
+  "version": "0.5.5",
   "description": "Typescript Networking Library for the Yext Chat API",
   "main": "./dist/commonjs/index.js",
   "module": "./dist/esm/index.js",

--- a/src/models/endpoints/MessageResponse.ts
+++ b/src/models/endpoints/MessageResponse.ts
@@ -7,8 +7,13 @@ import { MessageNotes } from "./MessageNotes";
  * @public
  */
 export interface MessageResponse {
-  /** The id corresponds to the current conversation. */
-  conversationId: string;
+  /**
+   * The id corresponds to the current conversation.
+   * 
+   * @remarks
+   * This is undefined only when it's an initial bot response without any user message present.
+   */
+  conversationId?: string;
   /** The generated reply to the latest message in the request. */
   message: Message;
   /** {@inheritDoc MessageNotes} */

--- a/test-browser-esm/package-lock.json
+++ b/test-browser-esm/package-lock.json
@@ -21,7 +21,7 @@
     },
     "..": {
       "name": "@yext/chat-core",
-      "version": "0.5.3",
+      "version": "0.5.5",
       "license": "BSD-3-Clause",
       "dependencies": {
         "cross-fetch": "^3.1.5"


### PR DESCRIPTION
As discussed in this thread (https://gerrit.yext.com/c/alpha/+/219444/16..23/src/com/yext/analytics/queries/schemas/chat/ChatSchema.java#b216) and in standup, as part of the effort to redefined NEW_CONVERSATION (aka omit initial bot messages), conversationId is only generated in the response IF the response is a non-initial bot message

J=CLIP-391
TEST=manual

spin up liveapigateway and chatapiserver. Use the test-site in chatcore to send requests to the local server:
see that sending an empty messages array provide the initial message without convo idand sending a populated messages array generated a new conversationId