### PR TITLE
Migrate from tsc to rollup for the build process

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@yext/chat-core",
-  "version": "0.6.1",
+  "version": "0.7.0-alpha.23",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@yext/chat-core",
-      "version": "0.6.1",
+      "version": "0.7.0-alpha.23",
       "license": "BSD-3-Clause",
       "dependencies": {
         "cross-fetch": "^3.1.5"

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@yext/chat-core",
-  "version": "0.7.0-alpha.23",
+  "version": "0.7.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@yext/chat-core",
-      "version": "0.7.0-alpha.23",
+      "version": "0.7.0",
       "license": "BSD-3-Clause",
       "dependencies": {
         "cross-fetch": "^3.1.5"

--- a/package-lock.json
+++ b/package-lock.json
@@ -25,6 +25,8 @@
         "jest": "^29.5.0",
         "jest-environment-jsdom": "^29.5.0",
         "prettier": "^2.8.8",
+        "rollup": "^3.29.0",
+        "rollup-plugin-typescript2": "^0.35.0",
         "typescript": "^5.0.4"
       }
     },
@@ -2874,6 +2876,19 @@
         "node": ">= 8"
       }
     },
+    "node_modules/@rollup/pluginutils": {
+      "version": "4.2.1",
+      "resolved": "https://registry.npmjs.org/@rollup/pluginutils/-/pluginutils-4.2.1.tgz",
+      "integrity": "sha512-iKnFXr7NkdZAIHiIWE+BX5ULi/ucVFYWD6TbAV+rZctiRTY2PL6tsIKhoIOaoskiWAkgu+VsbXgUVDNLHf+InQ==",
+      "dev": true,
+      "dependencies": {
+        "estree-walker": "^2.0.1",
+        "picomatch": "^2.2.2"
+      },
+      "engines": {
+        "node": ">= 8.0.0"
+      }
+    },
     "node_modules/@rushstack/eslint-patch": {
       "version": "1.3.0",
       "resolved": "https://registry.npmjs.org/@rushstack/eslint-patch/-/eslint-patch-1.3.0.tgz",
@@ -4289,6 +4304,12 @@
         "node": "^12.20.0 || >=14"
       }
     },
+    "node_modules/commondir": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/commondir/-/commondir-1.0.1.tgz",
+      "integrity": "sha512-W9pAhw0ja1Edb5GVdIF1mjZw/ASI0AlShXM83UUGe2DVr5TdAPEA1OA8m/g8zWp9x6On7gqufY+FatDbC3MDQg==",
+      "dev": true
+    },
     "node_modules/concat-map": {
       "version": "0.0.1",
       "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
@@ -5429,6 +5450,12 @@
         "node": ">=4.0"
       }
     },
+    "node_modules/estree-walker": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-2.0.2.tgz",
+      "integrity": "sha512-Rfkk/Mp/DL7JVje3u18FxFujQlTNR2q6QfMSMB7AvCBx91NGj/ba3kCfza0f6dVDbw7YlRf/nDrn7pQrCCyQ/w==",
+      "dev": true
+    },
     "node_modules/esutils": {
       "version": "2.0.3",
       "resolved": "https://registry.npmjs.org/esutils/-/esutils-2.0.3.tgz",
@@ -5572,6 +5599,23 @@
       },
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/find-cache-dir": {
+      "version": "3.3.2",
+      "resolved": "https://registry.npmjs.org/find-cache-dir/-/find-cache-dir-3.3.2.tgz",
+      "integrity": "sha512-wXZV5emFEjrridIgED11OoUKLxiYjAcqot/NJdAkOhlJ+vGzwhOAfcG5OX1jP+S0PcjEn8bdMJv+g2jwQ3Onig==",
+      "dev": true,
+      "dependencies": {
+        "commondir": "^1.0.1",
+        "make-dir": "^3.0.2",
+        "pkg-dir": "^4.1.0"
+      },
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/avajs/find-cache-dir?sponsor=1"
       }
     },
     "node_modules/find-up": {
@@ -8675,6 +8719,80 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/rollup": {
+      "version": "3.29.0",
+      "resolved": "https://registry.npmjs.org/rollup/-/rollup-3.29.0.tgz",
+      "integrity": "sha512-nszM8DINnx1vSS+TpbWKMkxem0CDWk3cSit/WWCBVs9/JZ1I/XLwOsiUglYuYReaeWWSsW9kge5zE5NZtf/a4w==",
+      "dev": true,
+      "bin": {
+        "rollup": "dist/bin/rollup"
+      },
+      "engines": {
+        "node": ">=14.18.0",
+        "npm": ">=8.0.0"
+      },
+      "optionalDependencies": {
+        "fsevents": "~2.3.2"
+      }
+    },
+    "node_modules/rollup-plugin-typescript2": {
+      "version": "0.35.0",
+      "resolved": "https://registry.npmjs.org/rollup-plugin-typescript2/-/rollup-plugin-typescript2-0.35.0.tgz",
+      "integrity": "sha512-szcIO9hPUx3PhQl91u4pfNAH2EKbtrXaES+m163xQVE5O1CC0ea6YZV/5woiDDW3CR9jF2CszPrKN+AFiND0bg==",
+      "dev": true,
+      "dependencies": {
+        "@rollup/pluginutils": "^4.1.2",
+        "find-cache-dir": "^3.3.2",
+        "fs-extra": "^10.0.0",
+        "semver": "^7.3.7",
+        "tslib": "^2.4.0"
+      },
+      "peerDependencies": {
+        "rollup": ">=1.26.3",
+        "typescript": ">=2.4.0"
+      }
+    },
+    "node_modules/rollup-plugin-typescript2/node_modules/fs-extra": {
+      "version": "10.1.0",
+      "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-10.1.0.tgz",
+      "integrity": "sha512-oRXApq54ETRj4eMiFzGnHWGy+zo5raudjuxN0b8H7s/RU2oW0Wvsx9O0ACRN/kRq9E8Vu/ReskGB5o3ji+FzHQ==",
+      "dev": true,
+      "dependencies": {
+        "graceful-fs": "^4.2.0",
+        "jsonfile": "^6.0.1",
+        "universalify": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/rollup-plugin-typescript2/node_modules/jsonfile": {
+      "version": "6.1.0",
+      "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-6.1.0.tgz",
+      "integrity": "sha512-5dgndWOriYSm5cnYaJNhalLNDKOqFwyDB/rr1E9ZsGciGvKPs8R2xYGCacuf3z6K1YKDz182fd+fY3cn3pMqXQ==",
+      "dev": true,
+      "dependencies": {
+        "universalify": "^2.0.0"
+      },
+      "optionalDependencies": {
+        "graceful-fs": "^4.1.6"
+      }
+    },
+    "node_modules/rollup-plugin-typescript2/node_modules/tslib": {
+      "version": "2.6.2",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.6.2.tgz",
+      "integrity": "sha512-AEYxH93jGFPn/a2iVAwW87VuUIkR1FVUKB77NwMF7nBTDkDrrT/Hpt/IrCJ0QXhW27jTBDcf5ZY7w6RiqTMw2Q==",
+      "dev": true
+    },
+    "node_modules/rollup-plugin-typescript2/node_modules/universalify": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/universalify/-/universalify-2.0.0.tgz",
+      "integrity": "sha512-hAZsKq7Yy11Zu1DE0OzWjw7nnLZmJZYTDZZyEFHZdUhV8FkH5MCfoU1XMaxXovpyW5nq5scPqq0ZDP9Zyl04oQ==",
+      "dev": true,
+      "engines": {
+        "node": ">= 10.0.0"
       }
     },
     "node_modules/run-parallel": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@yext/chat-core",
-  "version": "0.6.1",
+  "version": "0.7.0-alpha.23",
   "description": "Typescript Networking Library for the Yext Chat API",
   "main": "./dist/commonjs/index.js",
   "module": "./dist/esm/index.mjs",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@yext/chat-core",
-  "version": "0.7.0-alpha.23",
+  "version": "0.7.0",
   "description": "Typescript Networking Library for the Yext Chat API",
   "main": "./dist/commonjs/index.js",
   "module": "./dist/esm/index.mjs",

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "version": "0.6.1",
   "description": "Typescript Networking Library for the Yext Chat API",
   "main": "./dist/commonjs/index.js",
-  "module": "./dist/esm/index.js",
+  "module": "./dist/esm/index.mjs",
   "types": "./dist/esm/index.d.ts",
   "sideEffects": false,
   "keywords": [
@@ -26,12 +26,12 @@
   "scripts": {
     "test": "jest --config=jest.config.json",
     "lint": "prettier --write . && eslint --fix --max-warnings=0 .",
-    "tsc-cjs": "tsc -p tsconfig.cjs.json",
-    "tsc-esm": "tsc -p tsconfig.esm.json",
-    "dev": "npm run tsc-esm -- --watch",
+    "tsc": "tsc -p tsconfig.json",
+    "dev": "npm run tsc -- --watch",
     "generate-notices": "generate-license-file --input package.json --output THIRD-PARTY-NOTICES --overwrite",
     "generate-docs": "api-extractor run --local --verbose && api-documenter markdown --input-folder temp --output-folder docs && rm -rf temp",
-    "build": "rm -rf dist/** && npm run tsc-esm && npm run tsc-cjs && npm run generate-docs && npm run generate-notices"
+    "build:js": "rollup --config rollup.config.mjs",
+    "build": "rm -rf dist/** && npm run build:js && npm run generate-docs && npm run generate-notices"
   },
   "repository": {
     "type": "git",
@@ -60,6 +60,8 @@
     "jest": "^29.5.0",
     "jest-environment-jsdom": "^29.5.0",
     "prettier": "^2.8.8",
+    "rollup": "^3.29.0",
+    "rollup-plugin-typescript2": "^0.35.0",
     "typescript": "^5.0.4"
   }
 }

--- a/rollup.config.mjs
+++ b/rollup.config.mjs
@@ -1,0 +1,42 @@
+/**
+ * \@rollup/plugin-typescript had issue with "export type":
+ * [!] RollupError: Unexpected token (Note that you need plugins to import files that are not JavaScript)
+ * Switched over to a fork rollup-plugin-typescript2 resolved the issue.
+ */
+import typescript from "rollup-plugin-typescript2";
+import { defineConfig } from "rollup";
+
+export default defineConfig({
+  input: "src/index.ts",
+  output: [
+    {
+      dir: "./dist/esm",
+      /**
+       * use mjs extension so NodeJS will recognize the bundle as ES modules
+       * https://nodejs.org/api/packages.html#determining-module-system
+       */
+      entryFileNames: "[name].mjs",
+      format: "esm",
+      /** preserve original module files instead of compressing all to one file */
+      preserveModules: true,
+      sourcemap: true,
+      /**
+       * set to "auto" to follow TypeScript's esModuleInterop behavior to ensures compatibility
+       * of default, namespace, and dynamic imports from external deps (e.g. react-textarea-autosize).
+       */
+      interop: "auto",
+    },
+    {
+      dir: "./dist/commonjs",
+      format: "cjs",
+      preserveModules: true,
+      sourcemap: true,
+      interop: "auto",
+    },
+  ],
+  plugins: [
+    typescript({
+      tsconfig: "./tsconfig.json",
+    }),
+  ],
+});

--- a/src/infra/ChatCoreImpl.ts
+++ b/src/infra/ChatCoreImpl.ts
@@ -9,11 +9,9 @@ import {
   MessageRequest,
   MessageResponse,
   Endpoints,
-  ChatPrompt
+  ChatPrompt,
 } from "../models";
-import {
-  ApiMessageRequest,
-} from "../models/endpoints/MessageRequest";
+import { ApiMessageRequest } from "../models/endpoints/MessageRequest";
 import { ApiResponse } from "../models/http/ApiResponse";
 import { QueryParams } from "../models/http/params";
 import { ApiResponseValidator } from "../validation/ApiResponseValidator";

--- a/src/models/ChatCore.ts
+++ b/src/models/ChatCore.ts
@@ -1,10 +1,10 @@
-import { StreamResponse } from "../infra/StreamResponse"
-import { MessageRequest } from "./endpoints/MessageRequest"
-import { MessageResponse } from "./endpoints/MessageResponse"
+import { StreamResponse } from "../infra/StreamResponse";
+import { MessageRequest } from "./endpoints/MessageRequest";
+import { MessageResponse } from "./endpoints/MessageResponse";
 
 /**
  * Provide methods for interacting with Chat API.
- * 
+ *
  * @public
  */
 export interface ChatCore {
@@ -16,7 +16,7 @@ export interface ChatCore {
    *
    * @param request - request to get next message
    */
-  getNextMessage(request: MessageRequest): Promise<MessageResponse>
+  getNextMessage(request: MessageRequest): Promise<MessageResponse>;
   /**
    * Make a request to Chat streaming API to generate the next message
    * and consume its tokens via server-sent events.
@@ -28,5 +28,5 @@ export interface ChatCore {
    *
    * @param request - request to get next message
    */
-  streamNextMessage(request: MessageRequest): Promise<StreamResponse>
+  streamNextMessage(request: MessageRequest): Promise<StreamResponse>;
 }

--- a/src/models/InternalConfig.ts
+++ b/src/models/InternalConfig.ts
@@ -4,7 +4,7 @@
  * package and subsequently moved into "stable" after performance and
  * reliability are verified. It is STRONGLY recommended not to use
  * "nightly" in production Chat bots.
- * 
+ *
  * @internal
  */
 export type ChatPrompt = "stable" | "nightly";

--- a/src/models/endpoints/MessageResponse.ts
+++ b/src/models/endpoints/MessageResponse.ts
@@ -9,7 +9,7 @@ import { MessageNotes } from "./MessageNotes";
 export interface MessageResponse {
   /**
    * The id corresponds to the current conversation.
-   * 
+   *
    * @remarks
    * This is undefined only when it's an initial bot response without any user message present.
    */

--- a/src/models/index.ts
+++ b/src/models/index.ts
@@ -1,6 +1,6 @@
-export { ChatCore } from "./ChatCore"
+export { ChatCore } from "./ChatCore";
 export { ChatConfig } from "./ChatConfig";
-export { InternalConfig, ChatPrompt } from "./InternalConfig"
+export { InternalConfig, ChatPrompt } from "./InternalConfig";
 
 export { Endpoints } from "./endpoints/Endpoints";
 export { Environment } from "./endpoints/Environment";

--- a/test-browser-esm/package-lock.json
+++ b/test-browser-esm/package-lock.json
@@ -21,7 +21,7 @@
     },
     "..": {
       "name": "@yext/chat-core",
-      "version": "0.6.1",
+      "version": "0.7.0",
       "license": "BSD-3-Clause",
       "dependencies": {
         "cross-fetch": "^3.1.5"

--- a/test-browser-esm/package-lock.json
+++ b/test-browser-esm/package-lock.json
@@ -40,6 +40,8 @@
         "jest": "^29.5.0",
         "jest-environment-jsdom": "^29.5.0",
         "prettier": "^2.8.8",
+        "rollup": "^3.29.0",
+        "rollup-plugin-typescript2": "^0.35.0",
         "typescript": "^5.0.4"
       }
     },

--- a/test-browser-esm/src/script.js
+++ b/test-browser-esm/src/script.js
@@ -1,13 +1,13 @@
-import { ChatCore, StreamEventName } from "@yext/chat-core";
+import { StreamEventName, provideChatCore } from "@yext/chat-core";
 
-let chatCore = new ChatCore({
+let chatCore = provideChatCore({
   // will be replace with actual env value during rollup build process
   apiKey: process.env.TEST_BOT_API_KEY || "API_KEY_PLACEHOLDER",
   botId: process.env.TEST_BOT_ID,
   endpoints: {
     chat: `https://liveapi-dev.yext.com/v2/accounts/me/chat/${process.env.TEST_BOT_ID}/message`,
     chatStream: `https://liveapi-dev.yext.com/v2/accounts/me/chat/${process.env.TEST_BOT_ID}/message/streaming`,
-  }
+  },
 });
 
 window.getNextMessage = async () => {

--- a/test-node-cjs/node.ts
+++ b/test-node-cjs/node.ts
@@ -1,18 +1,21 @@
 /* eslint-disable @typescript-eslint/no-explicit-any */
 import http from "http";
-import { ChatCore, StreamEventName } from "@yext/chat-core";
+import { ChatConfig, StreamEventName, provideChatCore } from "@yext/chat-core";
 import dotenv from "dotenv";
 
 dotenv.config();
 
-const config = {
+const config: ChatConfig = {
   apiKey: process.env["TEST_BOT_API_KEY"] || "API_KEY_PLACEHOLDER",
   botId: process.env["TEST_BOT_ID"] || "BOT_ID_PLACEHOLDER",
-  apiDomain: "liveapi-dev.yext.com",
+  endpoints: {
+    chat: `https://liveapi-dev.yext.com/v2/accounts/me/chat/${process.env.TEST_BOT_ID}/message`,
+    chatStream: `https://liveapi-dev.yext.com/v2/accounts/me/chat/${process.env.TEST_BOT_ID}/message/streaming`,
+  },
 };
 
 async function stream(res: any) {
-  const chatCore = new ChatCore(config);
+  const chatCore = provideChatCore(config);
   const stream = await chatCore.streamNextMessage({
     messages: [
       {
@@ -39,7 +42,7 @@ const server = http.createServer(async (req: any, res: any) => {
   if (req.url === "/streaming") {
     stream(res);
   } else {
-    const chatCore = new ChatCore(config);
+    const chatCore = provideChatCore(config);
     const reply = await chatCore.getNextMessage({
       messages: [],
     });

--- a/test-node-cjs/package-lock.json
+++ b/test-node-cjs/package-lock.json
@@ -19,7 +19,7 @@
     },
     "..": {
       "name": "@yext/chat-core",
-      "version": "0.6.1",
+      "version": "0.7.0",
       "license": "BSD-3-Clause",
       "dependencies": {
         "cross-fetch": "^3.1.5"

--- a/test-node-cjs/package-lock.json
+++ b/test-node-cjs/package-lock.json
@@ -38,6 +38,8 @@
         "jest": "^29.5.0",
         "jest-environment-jsdom": "^29.5.0",
         "prettier": "^2.8.8",
+        "rollup": "^3.29.0",
+        "rollup-plugin-typescript2": "^0.35.0",
         "typescript": "^5.0.4"
       }
     },


### PR DESCRIPTION
this PR migrates the build chain from tsc to rollup, as part of the changes discovered in the investigation from this [PR](https://github.com/yext/chat-ui-react/pull/38): 

in short, using rollup, the esm path files now include `.mjs` extensions and we no longer need `"type": "module"` in our package.json.

J=CLIP-556
TEST=manual

see that all unit tests and the the two test repo, node-cjs, and brower-esm, still works as expected
published an alpha version `[0.7.0-alpha.23](https://www.npmjs.com/package/@yext/chat-core/v/0.7.0-alpha.23)`, and see that it still works as expected in vite/pagesjs and sonic/alpha.

Will publish v0.7.0 once merged