### PR TITLE
bug: Version should be strictly string

### DIFF
--- a/docs/chat-core.chatconfig.md
+++ b/docs/chat-core.chatconfig.md
@@ -22,5 +22,5 @@ export interface ChatConfig
 |  [endpoints?](./chat-core.chatconfig.endpoints.md) |  | [Endpoints](./chat-core.endpoints.md) | _(Optional)_ Overrides for the URLs which are used when making requests to the Chat API. |
 |  [env?](./chat-core.chatconfig.env.md) |  | [EnumOrLiteral](./chat-core.enumorliteral.md)<!-- -->&lt;[Environment](./chat-core.environment.md)<!-- -->&gt; | _(Optional)_ Defines the environment of the API domains. |
 |  [region?](./chat-core.chatconfig.region.md) |  | [EnumOrLiteral](./chat-core.enumorliteral.md)<!-- -->&lt;[Region](./chat-core.region.md)<!-- -->&gt; | _(Optional)_ The region to send the requests to. |
-|  [version?](./chat-core.chatconfig.version.md) |  | "STAGING" \| "PRODUCTION" \| number | _(Optional)_ The version of the chat bot configuration. |
+|  [version?](./chat-core.chatconfig.version.md) |  | string | _(Optional)_ The version of the chat bot configuration. |
 

--- a/docs/chat-core.chatconfig.version.md
+++ b/docs/chat-core.chatconfig.version.md
@@ -9,14 +9,14 @@ The version of the chat bot configuration.
 **Signature:**
 
 ```typescript
-version?: "STAGING" | "PRODUCTION" | number;
+version?: string;
 ```
 
 ## Remarks
 
-May be a configuration label (string) or a configuration version (number). Default to 'STAGING' in Chat API
+Default to 'STAGING' in Chat API
 
 ## Example
 
-Examples: 'STAGING', 42
+Examples: 'STAGING', 'PRODUCTION', '42'
 

--- a/etc/chat-core.api.md
+++ b/etc/chat-core.api.md
@@ -14,7 +14,7 @@ export interface ChatConfig {
     endpoints?: Endpoints;
     env?: EnumOrLiteral<Environment>;
     region?: EnumOrLiteral<Region>;
-    version?: "STAGING" | "PRODUCTION" | number;
+    version?: string;
 }
 
 // @public

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@yext/chat-core",
-  "version": "0.7.1",
+  "version": "0.7.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@yext/chat-core",
-      "version": "0.7.1",
+      "version": "0.7.2",
       "license": "BSD-3-Clause",
       "dependencies": {
         "cross-fetch": "^3.1.5"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@yext/chat-core",
-  "version": "0.7.1",
+  "version": "0.7.2",
   "description": "Typescript Networking Library for the Yext Chat API",
   "main": "./dist/commonjs/index.js",
   "module": "./dist/esm/index.mjs",

--- a/src/models/ChatConfig.ts
+++ b/src/models/ChatConfig.ts
@@ -19,13 +19,12 @@ export interface ChatConfig {
    * The version of the chat bot configuration.
    *
    * @remarks
-   * May be a configuration label (string) or a configuration version (number).
    * Default to 'STAGING' in Chat API
    *
    * @example
-   * Examples: 'STAGING', 42
+   * Examples: 'STAGING', 'PRODUCTION', '42'
    */
-  version?: "STAGING" | "PRODUCTION" | number;
+  version?: string;
   /**
    * Defines the environment of the API domains.
    *

--- a/src/models/endpoints/MessageRequest.ts
+++ b/src/models/endpoints/MessageRequest.ts
@@ -51,7 +51,7 @@ export interface ApiMessageRequest {
   /** {@inheritdoc MessageRequest.conversationId} */
   conversationId?: string;
   /** {@inheritDoc ChatConfig.version} */
-  version?: "STAGING" | "PRODUCTION" | number;
+  version?: string;
   /** {@inheritDoc MessageRequest.messages} */
   messages: Message[];
   /** {@inheritDoc MessageNotes} */

--- a/test-browser-esm/package-lock.json
+++ b/test-browser-esm/package-lock.json
@@ -21,7 +21,7 @@
     },
     "..": {
       "name": "@yext/chat-core",
-      "version": "0.7.0",
+      "version": "0.7.2",
       "license": "BSD-3-Clause",
       "dependencies": {
         "cross-fetch": "^3.1.5"

--- a/test-node-cjs/package-lock.json
+++ b/test-node-cjs/package-lock.json
@@ -19,7 +19,7 @@
     },
     "..": {
       "name": "@yext/chat-core",
-      "version": "0.7.1",
+      "version": "0.7.2",
       "license": "BSD-3-Clause",
       "dependencies": {
         "cross-fetch": "^3.1.5"

--- a/tests/ChatCore.test.ts
+++ b/tests/ChatCore.test.ts
@@ -156,7 +156,7 @@ describe("URL and http request construction", () => {
 
   const configWithVersion: ChatConfig = {
     ...defaultConfig,
-    version: 42,
+    version: '42',
   };
 
   it("sets custom version when specified for Chat API", async () => {
@@ -167,7 +167,7 @@ describe("URL and http request construction", () => {
       "https://liveapi.yext.com/v2/accounts/me/chat/my-bot/message",
       { v: defaultApiVersion },
       {
-        version: 42,
+        version: '42',
         conversationId: "my-id",
         context: {
           foo: "bar",
@@ -186,7 +186,7 @@ describe("URL and http request construction", () => {
       "https://liveapi.yext.com/v2/accounts/me/chat/my-bot/message/streaming",
       { v: defaultApiVersion },
       {
-        version: 42,
+        version: '42',
         conversationId: "my-id",
         context: {
           foo: "bar",


### PR DESCRIPTION
Error out with version as number:
<img width="607" alt="Screenshot 2023-10-10 at 4 47 55 PM" src="https://github.com/yext/chat-core/assets/36055303/0c939f9e-b16d-4e14-a63a-2a1ad02d29c8">

J=CLIP-693

see that it works with version = '51' and not version 52