### PR TITLE
Update domain to `cdn.yextapis.com`

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@yext/chat-core",
-  "version": "0.7.2",
+  "version": "0.7.3",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@yext/chat-core",
-      "version": "0.7.2",
+      "version": "0.7.3",
       "license": "BSD-3-Clause",
       "dependencies": {
         "cross-fetch": "^3.1.5"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@yext/chat-core",
-  "version": "0.7.2",
+  "version": "0.7.3",
   "description": "Typescript Networking Library for the Yext Chat API",
   "main": "./dist/commonjs/index.js",
   "module": "./dist/esm/index.mjs",

--- a/src/infra/EndpointsFactory.ts
+++ b/src/infra/EndpointsFactory.ts
@@ -15,9 +15,9 @@ export class EndpointsFactory {
       case Region.US:
         switch (env) {
           case Environment.SANDBOX:
-            return "liveapi-sandbox.yext.com";
+            return "sbx-cdn.yextapis.com";
           default:
-            return "liveapi.yext.com";
+            return "cdn.yextapis.com";
         }
       case Region.EU:
         if (env === Environment.PRODUCTION) {

--- a/tests/ChatCore.test.ts
+++ b/tests/ChatCore.test.ts
@@ -90,7 +90,7 @@ describe("URL and http request construction", () => {
     const chatCore = provideChatCore(defaultConfig);
     await chatCore.getNextMessage(mockedMessageRequest);
     expect(httpServiceSpy).toHaveBeenCalledWith(
-      "https://liveapi.yext.com/v2/accounts/me/chat/my-bot/message",
+      "https://cdn.yextapis.com/v2/accounts/me/chat/my-bot/message",
       { v: defaultApiVersion },
       mockedMessageRequest,
       "my-api-key"
@@ -102,7 +102,7 @@ describe("URL and http request construction", () => {
     const chatCore = provideChatCore(defaultConfig);
     await chatCore.streamNextMessage(mockedMessageRequest);
     expect(httpServiceSpy).toHaveBeenCalledWith(
-      "https://liveapi.yext.com/v2/accounts/me/chat/my-bot/message/streaming",
+      "https://cdn.yextapis.com/v2/accounts/me/chat/my-bot/message/streaming",
       { v: defaultApiVersion },
       mockedMessageRequest,
       "my-api-key"
@@ -164,7 +164,7 @@ describe("URL and http request construction", () => {
     const chatCore = provideChatCore(configWithVersion);
     await chatCore.getNextMessage(mockedMessageRequest);
     expect(httpServiceSpy).toHaveBeenCalledWith(
-      "https://liveapi.yext.com/v2/accounts/me/chat/my-bot/message",
+      "https://cdn.yextapis.com/v2/accounts/me/chat/my-bot/message",
       { v: defaultApiVersion },
       {
         version: '42',
@@ -183,7 +183,7 @@ describe("URL and http request construction", () => {
     const chatCore = provideChatCore(configWithVersion);
     await chatCore.streamNextMessage(mockedMessageRequest);
     expect(httpServiceSpy).toHaveBeenCalledWith(
-      "https://liveapi.yext.com/v2/accounts/me/chat/my-bot/message/streaming",
+      "https://cdn.yextapis.com/v2/accounts/me/chat/my-bot/message/streaming",
       { v: defaultApiVersion },
       {
         version: '42',

--- a/tests/infra/EndPointFactory.test.ts
+++ b/tests/infra/EndPointFactory.test.ts
@@ -5,8 +5,8 @@ it("provides proper endpoint for default env, region, and businessId", () => {
     botId: "my-bot",
   });
   expect(endpoints).toEqual({
-    chat: `https://liveapi.yext.com/v2/accounts/me/chat/my-bot/message`,
-    chatStream: `https://liveapi.yext.com/v2/accounts/me/chat/my-bot/message/streaming`,
+    chat: `https://cdn.yextapis.com/v2/accounts/me/chat/my-bot/message`,
+    chatStream: `https://cdn.yextapis.com/v2/accounts/me/chat/my-bot/message/streaming`,
   });
 });
 
@@ -16,8 +16,8 @@ it("provides proper endpoint for custom env", () => {
     env: "SANDBOX",
   });
   expect(endpoints).toEqual({
-    chat: `https://liveapi-sandbox.yext.com/v2/accounts/me/chat/my-bot/message`,
-    chatStream: `https://liveapi-sandbox.yext.com/v2/accounts/me/chat/my-bot/message/streaming`,
+    chat: `https://sbx-cdn.yextapis.com/v2/accounts/me/chat/my-bot/message`,
+    chatStream: `https://sbx-cdn.yextapis.com/v2/accounts/me/chat/my-bot/message/streaming`,
   });
 });
 
@@ -38,8 +38,8 @@ it("provides proper endpoint for custom businessId", () => {
     businessId: 123,
   });
   expect(endpoints).toEqual({
-    chat: `https://liveapi.yext.com/v2/accounts/123/chat/my-bot/message`,
-    chatStream: `https://liveapi.yext.com/v2/accounts/123/chat/my-bot/message/streaming`,
+    chat: `https://cdn.yextapis.com/v2/accounts/123/chat/my-bot/message`,
+    chatStream: `https://cdn.yextapis.com/v2/accounts/123/chat/my-bot/message/streaming`,
   });
 });
 


### PR DESCRIPTION
update endpoint from `liveapi.yext.com` to `cdn.yextapis.com` for PROD and SANDBOX in US region.

J=CLIP-539
TEST=manual

see that I get successful responses using bots from prod and sandbox account:
![Screenshot 2023-10-12 at 2 27 45 PM](https://github.com/yext/chat-core/assets/36055303/4cf7d11c-4426-4ca2-8043-27366c16e152)
![Screenshot 2023-10-12 at 2 28 18 PM](https://github.com/yext/chat-core/assets/36055303/51ad5b4c-95f8-42b3-90d8-81f17471c968)
