### PR TITLE
Remove aiMode configuration

### DIFF
--- a/etc/chat-core.api.md
+++ b/etc/chat-core.api.md
@@ -65,7 +65,6 @@ export enum Environment {
 //
 // @internal
 export interface InternalConfig {
-    aiMode?: string;
     promptPackage?: ChatPrompt;
 }
 

--- a/src/infra/ChatCoreImpl.ts
+++ b/src/infra/ChatCoreImpl.ts
@@ -41,7 +41,6 @@ export class ChatCoreImpl implements ChatCore {
       ...request,
       version: this.chatConfig.version,
       promptPackage: this.internalConfig.promptPackage,
-      aiMode: this.internalConfig.aiMode,
     };
     const rawResponse = await this.httpService.post(
       this.endpoints.chat,
@@ -81,7 +80,6 @@ export class ChatCoreImpl implements ChatCore {
       ...request,
       version: this.chatConfig.version,
       promptPackage: this.internalConfig.promptPackage,
-      aiMode: this.internalConfig.aiMode,
     };
     const rawResponse = await this.httpService.post(
       this.endpoints.chatStream,

--- a/src/models/InternalConfig.ts
+++ b/src/models/InternalConfig.ts
@@ -26,9 +26,4 @@ export interface InternalConfig {
    * Defaults to "stable", which is the set of tested and verified prompts.
    */
   promptPackage?: ChatPrompt;
-  /**
-   * Modes to determine types of models to use when sending requests the bot's
-   * instruction steps.
-   */
-  aiMode?: string;
 }

--- a/src/models/endpoints/MessageRequest.ts
+++ b/src/models/endpoints/MessageRequest.ts
@@ -58,6 +58,4 @@ export interface ApiMessageRequest {
   notes?: MessageNotes;
   /** {@inheritDoc InternalConfig.promptPackage} */
   promptPackage?: ChatPrompt;
-  /** {@inheritDoc InternalConfig.aiMode} */
-  aiMode?: string;
 }


### PR DESCRIPTION
the experimental field `aiMode` is now replaced by prompt override configuration in bot config.

J=CLIP-1199
TEST=none