### PR TITLE
chat-core-aws-connect: session cleanup on close

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10274,7 +10274,7 @@
     },
     "packages/chat-core-aws-connect": {
       "name": "@yext/chat-core-aws-connect",
-      "version": "0.1.0",
+      "version": "0.1.0-alpha.2",
       "license": "BSD-3-Clause",
       "dependencies": {
         "amazon-connect-chatjs": "^2.3.0",

--- a/packages/chat-core-aws-connect/jest.config.json
+++ b/packages/chat-core-aws-connect/jest.config.json
@@ -3,7 +3,7 @@
   "collectCoverage": true,
   "collectCoverageFrom": ["src/**", "!src/models/**/*.ts"],
   "verbose": true,
-  "moduleFileExtensions": ["js", "ts"],
+  "moduleFileExtensions": ["js", "ts", "d.ts"],
   "moduleDirectories": ["node_modules", "<rootDir>"],
   "testEnvironment": "jsdom",
   "testPathIgnorePatterns": ["./tests/mocks/*", "./tests/jest-setup.js"],

--- a/packages/chat-core-aws-connect/package.json
+++ b/packages/chat-core-aws-connect/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@yext/chat-core-aws-connect",
-    "version": "0.1.0-alpha",
+    "version": "0.1.0-alpha.2",
     "description": "Typescript Networking Library for the Yext Chat API Integration with Amazon Connect",
     "main": "./dist/commonjs/index.js",
     "module": "./dist/esm/index.mjs",

--- a/packages/chat-core-aws-connect/src/infra/ChatCoreAwsConnectImpl.ts
+++ b/packages/chat-core-aws-connect/src/infra/ChatCoreAwsConnectImpl.ts
@@ -64,7 +64,7 @@ export class ChatCoreAwsConnectImpl implements ChatCoreAwsConnect {
     this.setupEventListeners();
     this.session.sendMessage({
       contentType: "text/plain",
-      message: messageRsp.notes.conversationSummary,
+      message: `SUMMARY: ${messageRsp.notes.conversationSummary}`,
     });
   }
 
@@ -96,6 +96,8 @@ export class ChatCoreAwsConnectImpl implements ChatCoreAwsConnect {
 
     this.session?.onEnded((event: AwsConnectEvent) => {
       this.eventListeners["close"]?.forEach((cb) => cb(event.data));
+      // Connection is closed. Clear session and create new one on next handoff request.
+      this.session = undefined;
     });
   }
 


### PR DESCRIPTION
Previously, after 15 minutes of inactivity, the session will be closed/disconnected but subsequent `init()` calls will not initialize a new session and reuse the old one. This throw an exception when processing user messages.

This PR clear `session` object in ChatCoreAwsConnect when `close` event is emitted from the socket. With subsequent handoff request, `init()` will create a new session to process user messages.

Also added a `SUMMARY: ` prefix to the first message of the chat session to clarify that the message is not directly from user (even though the source indicates user).

J=CLIP-1286
TEST=manual&auto

see that unit tests passed
used local build with chat-headless, created a chat session through user message, ended from agent side, and waited for 15 minutes for the connection to close. Then request another handoff through user message, see that a new chat session is created.