### PR TITLE
chat-core-zendesk: fetch new user's first conversation ID

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9560,7 +9560,7 @@
     },
     "packages/chat-core-zendesk": {
       "name": "@yext/chat-core-zendesk",
-      "version": "0.1.0",
+      "version": "0.1.1",
       "license": "BSD-3-Clause",
       "dependencies": {
         "smooch": "5.6.0"

--- a/packages/chat-core-zendesk/package.json
+++ b/packages/chat-core-zendesk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@yext/chat-core-zendesk",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "description": "Typescript Networking Library for the Yext Chat API Integration with Zendesk",
   "main": "./dist/commonjs/index.js",
   "module": "./dist/esm/index.mjs",

--- a/test-sites/test-browser-esm/package-lock.json
+++ b/test-sites/test-browser-esm/package-lock.json
@@ -88,7 +88,7 @@
         "@microsoft/api-extractor": "^7.34.8",
         "@types/jest": "^29.5.1",
         "@types/node-fetch": "^2.6.4",
-        "@yext/chat-core": "^0.8.2",
+        "@yext/chat-core": "^0.9.1",
         "@yext/eslint-config": "^1.0.0",
         "babel-jest": "^29.5.0",
         "dotenv": "^16.4.5",
@@ -102,7 +102,7 @@
         "typescript": "^5.0.4"
       },
       "peerDependencies": {
-        "@yext/chat-core": "^0.8.2"
+        "@yext/chat-core": "^0.9.1"
       }
     },
     "../../packages/chat-core-zendesk": {
@@ -119,7 +119,7 @@
         "@microsoft/api-extractor": "^7.34.8",
         "@types/jest": "^29.5.1",
         "@types/smooch": "^5.3.7",
-        "@yext/chat-core": "^0.8.2",
+        "@yext/chat-core": "^0.9.1",
         "@yext/eslint-config": "^1.0.0",
         "babel-jest": "^29.5.0",
         "eslint": "^8.39.0",
@@ -132,7 +132,7 @@
         "typescript": "^5.0.4"
       },
       "peerDependencies": {
-        "@yext/chat-core": "^0.8.2"
+        "@yext/chat-core": "^0.9.1"
       }
     },
     "node_modules/@jridgewell/sourcemap-codec": {


### PR DESCRIPTION
the returned conversation ID when invoking `Smooch.createConversation` for a new user is `TEMPORARY_CONVERSATION`. In order the the rest of the integration logic to work, we need the actual conversation ID. this PR updates it to re-fetch using `Smooch.getDisplayedConversation` to get the actual id for the session. Subsequent conversation creation do return the proper ID so this additional logic is not needed there

J=CLIP-1516
TEST=manual

clear all cookies and values in local/session storage to start as a new user, see that it no longer throws an error on the first conversation.