### PR TITLE
chat-core-zendesk: handle resolved ticket event

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9560,7 +9560,7 @@
     },
     "packages/chat-core-zendesk": {
       "name": "@yext/chat-core-zendesk",
-      "version": "0.1.1",
+      "version": "0.1.2",
       "license": "BSD-3-Clause",
       "dependencies": {
         "smooch": "5.6.0"

--- a/packages/chat-core-zendesk/package.json
+++ b/packages/chat-core-zendesk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@yext/chat-core-zendesk",
-  "version": "0.1.1",
+  "version": "0.1.2",
   "description": "Typescript Networking Library for the Yext Chat API Integration with Zendesk",
   "main": "./dist/commonjs/index.js",
   "module": "./dist/esm/index.mjs",

--- a/packages/chat-core-zendesk/tests/ChatCoreZendesk.test.ts
+++ b/packages/chat-core-zendesk/tests/ChatCoreZendesk.test.ts
@@ -144,7 +144,7 @@ it("triggers message event callbacks", async () => {
   const onMessageFn = onCbSpy.mock.calls[0][1] as any;
   // simulate a message event
   onMessageFn(
-    { text, type: "text" },
+    { text, type: "text", role: "business" },
     { conversation: { id: mockConversationId } }
   );
   expect(dummyFn).toBeCalledWith(text);

--- a/test-sites/test-browser-esm/package-lock.json
+++ b/test-sites/test-browser-esm/package-lock.json
@@ -107,7 +107,7 @@
     },
     "../../packages/chat-core-zendesk": {
       "name": "@yext/chat-core-zendesk",
-      "version": "0.1.0",
+      "version": "0.1.2",
       "license": "BSD-3-Clause",
       "dependencies": {
         "smooch": "5.6.0"


### PR DESCRIPTION
unlike deleting ticket, which trigger a passControl event and is handled by the internal bot in the switchboard, agent marking a ticket a resolved will not transfer control. Instead, zendesk will send a csat message (e.g. "how did the chat go?") to the conversation.

This PR will replace that message with `The agent has resolved the ticket. Further assistance will now be provided by the bot.` to inform the user and closes the session. The bot in the frontend will then resume the conversation on subsequent user messages.

J=CLIP-1530
TEST=manual

see that I get the custom message instead of "how did the chat go?" message from zendesk. See that the bot will resume conversation in the next message.

![Screenshot 2024-09-12 at 4 42 05 PM](https://github.com/user-attachments/assets/ff556439-65cf-47c2-9e7d-745d9dc3d5dc)