### PR TITLE
chat-core-zendesk: update ticket tag for agent handoff

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9560,7 +9560,7 @@
     },
     "packages/chat-core-zendesk": {
       "name": "@yext/chat-core-zendesk",
-      "version": "0.1.2",
+      "version": "0.1.3",
       "license": "BSD-3-Clause",
       "dependencies": {
         "smooch": "5.6.0"

--- a/packages/chat-core-zendesk/package.json
+++ b/packages/chat-core-zendesk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@yext/chat-core-zendesk",
-  "version": "0.1.2",
+  "version": "0.1.3",
   "description": "Typescript Networking Library for the Yext Chat API Integration with Zendesk",
   "main": "./dist/commonjs/index.js",
   "module": "./dist/esm/index.mjs",

--- a/packages/chat-core-zendesk/src/infra/ChatCoreZendeskImpl.ts
+++ b/packages/chat-core-zendesk/src/infra/ChatCoreZendeskImpl.ts
@@ -91,7 +91,7 @@ export class ChatCoreZendeskImpl {
   private async setupSession(messageRsp: MessageResponse) {
     let convo: Conversation = await Smooch.createConversation({
       metadata: {
-        "zen:ticket:tags": "yext-chat",
+        "zen:ticket:tags": "yext-chat-agent-handoff",
         // this indicates to the internal zendesk bot webhook that the conversation is from the Chat SDK
         [MetadataChatSDKKey]: true,
       },


### PR DESCRIPTION
the tag is colliding with existing tags for Yext advisor. Update it to be different. Will have a followup to allow this to be configurable when invoking `provideChatCoreZendesk` instead of hardcoding.