### PR TITLE
update @babel/plugin-transform-runtime to 7.25.9 to resolve vulnerability

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1621,16 +1621,17 @@
       }
     },
     "node_modules/@babel/plugin-transform-runtime": {
-      "version": "7.22.4",
+      "version": "7.25.9",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-runtime/-/plugin-transform-runtime-7.25.9.tgz",
+      "integrity": "sha512-nZp7GlEl+yULJrClz0SwHPqir3lc0zsPrDHQUcxGspSL7AKrexNSEfTbfqnDNJUO13bgKyfuOLMF8Xqtu8j3YQ==",
       "dev": true,
-      "license": "MIT",
       "dependencies": {
-        "@babel/helper-module-imports": "^7.21.4",
-        "@babel/helper-plugin-utils": "^7.21.5",
-        "babel-plugin-polyfill-corejs2": "^0.4.3",
-        "babel-plugin-polyfill-corejs3": "^0.8.1",
-        "babel-plugin-polyfill-regenerator": "^0.5.0",
-        "semver": "^6.3.0"
+        "@babel/helper-module-imports": "^7.25.9",
+        "@babel/helper-plugin-utils": "^7.25.9",
+        "babel-plugin-polyfill-corejs2": "^0.4.10",
+        "babel-plugin-polyfill-corejs3": "^0.10.6",
+        "babel-plugin-polyfill-regenerator": "^0.6.1",
+        "semver": "^6.3.1"
       },
       "engines": {
         "node": ">=6.9.0"
@@ -1639,49 +1640,11 @@
         "@babel/core": "^7.0.0-0"
       }
     },
-    "node_modules/@babel/plugin-transform-runtime/node_modules/@babel/helper-define-polyfill-provider": {
-      "version": "0.4.0",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@babel/helper-compilation-targets": "^7.17.7",
-        "@babel/helper-plugin-utils": "^7.16.7",
-        "debug": "^4.1.1",
-        "lodash.debounce": "^4.0.8",
-        "resolve": "^1.14.2",
-        "semver": "^6.1.2"
-      },
-      "peerDependencies": {
-        "@babel/core": "^7.4.0-0"
-      }
-    },
-    "node_modules/@babel/plugin-transform-runtime/node_modules/babel-plugin-polyfill-corejs3": {
-      "version": "0.8.1",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@babel/helper-define-polyfill-provider": "^0.4.0",
-        "core-js-compat": "^3.30.1"
-      },
-      "peerDependencies": {
-        "@babel/core": "^7.0.0-0"
-      }
-    },
-    "node_modules/@babel/plugin-transform-runtime/node_modules/babel-plugin-polyfill-regenerator": {
-      "version": "0.5.0",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@babel/helper-define-polyfill-provider": "^0.4.0"
-      },
-      "peerDependencies": {
-        "@babel/core": "^7.0.0-0"
-      }
-    },
     "node_modules/@babel/plugin-transform-runtime/node_modules/semver": {
-      "version": "6.3.0",
+      "version": "6.3.1",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.1.tgz",
+      "integrity": "sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA==",
       "dev": true,
-      "license": "ISC",
       "bin": {
         "semver": "bin/semver.js"
       }

--- a/packages/chat-core-aws-connect/THIRD-PARTY-NOTICES
+++ b/packages/chat-core-aws-connect/THIRD-PARTY-NOTICES
@@ -1939,7 +1939,7 @@ THE SOFTWARE.
 
 The following NPM package may be included in this product:
 
- - psl@1.10.0
+ - psl@1.12.0
 
 This package contains the following license and notice below:
 


### PR DESCRIPTION
A previous change bumped several Babel packages to resolve vulnerabilities, but missed this transitive vulnerability as part of @yext/eslint-config. This updates that dependency to a safe version.

TEST=manual

Ran `npm run lint`, saw no issues.