### PR TITLE
Address rollup vulnerabilities across packages

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -8210,9 +8210,10 @@
       }
     },
     "node_modules/rollup": {
-      "version": "3.29.0",
+      "version": "3.29.5",
+      "resolved": "https://registry.npmjs.org/rollup/-/rollup-3.29.5.tgz",
+      "integrity": "sha512-GVsDdsbJzzy4S/v3dqWPJ7EfvZJfCHiDqe80IyrF59LYuP+e6U1LJoUqeuqRbwAWoMNoXivMNeNAOf5E22VA1w==",
       "dev": true,
-      "license": "MIT",
       "bin": {
         "rollup": "dist/bin/rollup"
       },
@@ -9378,7 +9379,7 @@
         "jest": "^29.5.0",
         "jest-environment-jsdom": "^29.5.0",
         "prettier": "^2.8.8",
-        "rollup": "^3.29.0",
+        "rollup": "^3.29.5",
         "rollup-plugin-typescript2": "^0.35.0",
         "typescript": "^5.0.4"
       }
@@ -9406,7 +9407,7 @@
         "jest": "^29.5.0",
         "jest-environment-jsdom": "^29.5.0",
         "prettier": "^2.8.8",
-        "rollup": "^3.29.0",
+        "rollup": "^3.29.5",
         "rollup-plugin-typescript2": "^0.35.0",
         "typescript": "^5.0.4"
       },
@@ -9565,7 +9566,7 @@
     },
     "packages/chat-core-zendesk": {
       "name": "@yext/chat-core-zendesk",
-      "version": "0.3.0",
+      "version": "0.3.1",
       "license": "BSD-3-Clause",
       "dependencies": {
         "smooch": "5.6.0"
@@ -9585,7 +9586,7 @@
         "jest": "^29.5.0",
         "jest-environment-jsdom": "^29.5.0",
         "prettier": "^2.8.8",
-        "rollup": "^3.29.0",
+        "rollup": "^3.29.5",
         "rollup-plugin-typescript2": "^0.35.0",
         "typescript": "^5.0.4"
       },

--- a/packages/chat-core-aws-connect/package.json
+++ b/packages/chat-core-aws-connect/package.json
@@ -62,7 +62,7 @@
         "jest": "^29.5.0",
         "jest-environment-jsdom": "^29.5.0",
         "prettier": "^2.8.8",
-        "rollup": "^3.29.0",
+        "rollup": "^3.29.5",
         "rollup-plugin-typescript2": "^0.35.0",
         "typescript": "^5.0.4"
     },

--- a/packages/chat-core-zendesk/package.json
+++ b/packages/chat-core-zendesk/package.json
@@ -64,7 +64,7 @@
     "jest": "^29.5.0",
     "jest-environment-jsdom": "^29.5.0",
     "prettier": "^2.8.8",
-    "rollup": "^3.29.0",
+    "rollup": "^3.29.5",
     "rollup-plugin-typescript2": "^0.35.0",
     "typescript": "^5.0.4"
   },

--- a/packages/chat-core/package.json
+++ b/packages/chat-core/package.json
@@ -60,7 +60,7 @@
     "jest": "^29.5.0",
     "jest-environment-jsdom": "^29.5.0",
     "prettier": "^2.8.8",
-    "rollup": "^3.29.0",
+    "rollup": "^3.29.5",
     "rollup-plugin-typescript2": "^0.35.0",
     "typescript": "^5.0.4"
   }

--- a/packages/chat-core/test-node-cjs/package-lock.json
+++ b/packages/chat-core/test-node-cjs/package-lock.json
@@ -19,26 +19,26 @@
     },
     "..": {
       "name": "@yext/chat-core",
-      "version": "0.8.2",
+      "version": "0.9.1",
       "license": "BSD-3-Clause",
       "dependencies": {
         "cross-fetch": "^3.1.5"
       },
       "devDependencies": {
-        "@babel/preset-env": "^7.21.5",
+        "@babel/preset-env": "^7.26.0",
         "@babel/preset-typescript": "^7.21.5",
         "@microsoft/api-documenter": "^7.22.4",
         "@microsoft/api-extractor": "^7.34.8",
         "@types/jest": "^29.5.1",
         "@types/node-fetch": "^2.6.4",
-        "@yext/eslint-config": "^1.0.0",
+        "@yext/eslint-config": "^1.0.2",
         "babel-jest": "^29.5.0",
         "eslint": "^8.39.0",
         "generate-license-file": "^1.0.0",
         "jest": "^29.5.0",
         "jest-environment-jsdom": "^29.5.0",
         "prettier": "^2.8.8",
-        "rollup": "^3.29.0",
+        "rollup": "^3.29.5",
         "rollup-plugin-typescript2": "^0.35.0",
         "typescript": "^5.0.4"
       }

--- a/test-sites/test-browser-esm/package-lock.json
+++ b/test-sites/test-browser-esm/package-lock.json
@@ -17,7 +17,7 @@
         "@rollup/plugin-commonjs": "^24.1.0",
         "@rollup/plugin-node-resolve": "^15.0.2",
         "@rollup/plugin-replace": "^5.0.2",
-        "rollup": "^3.21.4",
+        "rollup": "^3.29.5",
         "serve": "^14.2.0"
       }
     },
@@ -69,7 +69,7 @@
         "jest": "^29.5.0",
         "jest-environment-jsdom": "^29.5.0",
         "prettier": "^2.8.8",
-        "rollup": "^3.29.0",
+        "rollup": "^3.29.5",
         "rollup-plugin-typescript2": "^0.35.0",
         "typescript": "^5.0.4"
       }
@@ -97,7 +97,7 @@
         "jest": "^29.5.0",
         "jest-environment-jsdom": "^29.5.0",
         "prettier": "^2.8.8",
-        "rollup": "^3.29.0",
+        "rollup": "^3.29.5",
         "rollup-plugin-typescript2": "^0.35.0",
         "typescript": "^5.0.4"
       },
@@ -107,7 +107,7 @@
     },
     "../../packages/chat-core-zendesk": {
       "name": "@yext/chat-core-zendesk",
-      "version": "0.3.0",
+      "version": "0.3.1",
       "license": "BSD-3-Clause",
       "dependencies": {
         "smooch": "5.6.0"
@@ -127,7 +127,7 @@
         "jest": "^29.5.0",
         "jest-environment-jsdom": "^29.5.0",
         "prettier": "^2.8.8",
-        "rollup": "^3.29.0",
+        "rollup": "^3.29.5",
         "rollup-plugin-typescript2": "^0.35.0",
         "typescript": "^5.0.4"
       },
@@ -1191,9 +1191,9 @@
       }
     },
     "node_modules/rollup": {
-      "version": "3.21.4",
-      "resolved": "https://registry.npmjs.org/rollup/-/rollup-3.21.4.tgz",
-      "integrity": "sha512-N5LxpvDolOm9ueiCp4NfB80omMDqb45ShtsQw2+OT3f11uJ197dv703NZvznYHP6RWR85wfxanXurXKG3ux2GQ==",
+      "version": "3.29.5",
+      "resolved": "https://registry.npmjs.org/rollup/-/rollup-3.29.5.tgz",
+      "integrity": "sha512-GVsDdsbJzzy4S/v3dqWPJ7EfvZJfCHiDqe80IyrF59LYuP+e6U1LJoUqeuqRbwAWoMNoXivMNeNAOf5E22VA1w==",
       "dev": true,
       "bin": {
         "rollup": "dist/bin/rollup"

--- a/test-sites/test-browser-esm/package.json
+++ b/test-sites/test-browser-esm/package.json
@@ -8,7 +8,7 @@
     "@rollup/plugin-commonjs": "^24.1.0",
     "@rollup/plugin-node-resolve": "^15.0.2",
     "@rollup/plugin-replace": "^5.0.2",
-    "rollup": "^3.21.4",
+    "rollup": "^3.29.5",
     "serve": "^14.2.0"
   },
   "dependencies": {


### PR DESCRIPTION
update rollup version to 3.29.5 (https://github.com/rollup/rollup/releases/tag/v3.29.5) which includes a vulnerability fix

J=VULN-39401,VULN-39402
TEST=manual

built all packages. Smoke test using test-node-cjs and test-browser-esm