### PR TITLE
chat-core-zendesk: workaround to inject ticket id to bot message

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9566,7 +9566,7 @@
     },
     "packages/chat-core-zendesk": {
       "name": "@yext/chat-core-zendesk",
-      "version": "0.3.1",
+      "version": "0.4.0",
       "license": "BSD-3-Clause",
       "dependencies": {
         "smooch": "5.6.0"

--- a/packages/chat-core-aws-connect/THIRD-PARTY-NOTICES
+++ b/packages/chat-core-aws-connect/THIRD-PARTY-NOTICES
@@ -194,7 +194,7 @@ The following NPM packages may be included in this product:
  - @types/istanbul-lib-report@3.0.3
  - @types/istanbul-reports@3.0.4
  - @types/jsdom@20.0.1
- - @types/node@22.10.1
+ - @types/node@22.10.2
  - @types/stack-utils@2.0.3
  - @types/tough-cookie@4.0.5
  - @types/yargs-parser@21.0.3

--- a/packages/chat-core-zendesk/package.json
+++ b/packages/chat-core-zendesk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@yext/chat-core-zendesk",
-  "version": "0.3.1",
+  "version": "0.4.0",
   "description": "Typescript Networking Library for the Yext Chat API Integration with Zendesk",
   "main": "./dist/commonjs/index.js",
   "module": "./dist/esm/index.mjs",

--- a/packages/chat-core-zendesk/tests/ChatCoreZendesk.test.ts
+++ b/packages/chat-core-zendesk/tests/ChatCoreZendesk.test.ts
@@ -28,6 +28,7 @@ jest.mock("smooch", () => ({
   render: jest.fn(),
   init: jest.fn(),
   createConversation: jest.fn(),
+  updateConversation: jest.fn(),
   loadConversation: jest.fn(),
   sendMessage: jest.fn(),
   on: jest.fn(),
@@ -297,6 +298,34 @@ it("sets ticket tags defined in config on handoff", async () => {
       "zen:ticket_field:field2": "value2",
       "zen:ticket:tags": "yext-chat-agent-handoff, tag1, tag2",
       YEXT_CHAT_SDK: true,
+    },
+  });
+});
+
+it("set conversation id to custom field on handoff", async () => {
+  const createConversationSpy = jest.spyOn(SmoochLib, "createConversation");
+  const updateConversationSpy = jest.spyOn(SmoochLib, "updateConversation");
+  const chatCoreZendesk = provideChatCoreZendesk(mockConfig);
+
+  await chatCoreZendesk.init({
+    ...mockMessageResponse(),
+    integrationDetails: {
+      zendeskHandoff: {
+        ticketFields: '{"123456": "SUNCO_CONVERSATION_ID_PLACEHOLDER"}',
+      },
+    },
+  });
+  expect(createConversationSpy).toBeCalledWith({
+    metadata: {
+      "zen:ticket:tags": "yext-chat-agent-handoff",
+      YEXT_CHAT_SDK: true,
+      "zen:ticket_field:123456": "SUNCO_CONVERSATION_ID_PLACEHOLDER",
+    },
+  });
+
+  expect(updateConversationSpy).toBeCalledWith(mockConversationId, {
+    metadata: {
+      "zen:ticket_field:123456": mockConversationId,
     },
   });
 });

--- a/test-sites/test-browser-esm/package-lock.json
+++ b/test-sites/test-browser-esm/package-lock.json
@@ -107,7 +107,7 @@
     },
     "../../packages/chat-core-zendesk": {
       "name": "@yext/chat-core-zendesk",
-      "version": "0.3.1",
+      "version": "0.4.0",
       "license": "BSD-3-Clause",
       "dependencies": {
         "smooch": "5.6.0"


### PR DESCRIPTION
This is part of a workaround in order enable the bot message to include the ticket ID when live messaging session has ended.
Zendesk does not have native support to easily access ticket ID within Sunco system and Zendesk system also cannot easily access Sunco conversation ID. So the workaround is as follow:
- SDK will provide the conversation ID in a custom ticket field
- Zendesk will have a trigger upon ticket creation with the agent handoff tag AND the conversation ID field is present, which will invoke a webhook to call a Sunco API to inject the ticket ID into the Sunco conversation's metadata
- When the messaging session is closed. The bot in the switchboard API will grab the ticket in the metadata and include it in its messaging when informing user of the closed session.

This PR implements the first step of the workaround. Additionally, the closing message on CSAT message type is removed as it should be now handled by the bot webhook in the switchboard as well.

Thread context: https://yext.slack.com/archives/C01CSDL5US0/p1733870484402519

J=CLIP-1649
TEST=manual&auto

added unit tests
setup trigger and webhook in the zendesk sandbox account and spin up local test site. Verified that the created ticket for the live messaging session contains the conversation ID in the custom field